### PR TITLE
Added UnitTests + Added Size Classes + Bug Fixes

### DIFF
--- a/EZSwiftExtensions.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensions.xcodeproj/project.pbxproj
@@ -8,6 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		31F868DB1C2B6E5E00542250 /* DoubleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F868DA1C2B6E5E00542250 /* DoubleExtensions.swift */; };
+		7605D3121C81FC180046FAC3 /* EZSwiftExtensionsTestsArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3021C81FBB80046FAC3 /* EZSwiftExtensionsTestsArray.swift */; };
+		7605D3131C81FC180046FAC3 /* EZSwiftExtensionsTestsBlockButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3031C81FBB80046FAC3 /* EZSwiftExtensionsTestsBlockButton.swift */; };
+		7605D3141C81FC180046FAC3 /* EZSwiftExtensionsTestsBool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3041C81FBB80046FAC3 /* EZSwiftExtensionsTestsBool.swift */; };
+		7605D3151C81FC180046FAC3 /* EZSwiftExtensionsTestsCGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3051C81FBB80046FAC3 /* EZSwiftExtensionsTestsCGFloat.swift */; };
+		7605D3161C81FC180046FAC3 /* EZSwiftExtensionsTestsDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3061C81FBB80046FAC3 /* EZSwiftExtensionsTestsDictionary.swift */; };
+		7605D3171C81FC180046FAC3 /* EZSwiftExtensionsTestsInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3071C81FBB80046FAC3 /* EZSwiftExtensionsTestsInt.swift */; };
+		7605D3181C81FC180046FAC3 /* EZSwiftExtensionsTestsNSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3081C81FBB80046FAC3 /* EZSwiftExtensionsTestsNSDate.swift */; };
+		7605D3191C81FC180046FAC3 /* EZSwiftExtensionsTestsString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7605D3091C81FBB80046FAC3 /* EZSwiftExtensionsTestsString.swift */; };
 		B5DC86AD1C0ED06700972D0A /* EZSwiftExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = B5DC86AC1C0ED06700972D0A /* EZSwiftExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5DC86B41C0ED06700972D0A /* EZSwiftExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5DC86A91C0ED06700972D0A /* EZSwiftExtensions.framework */; };
 		B5DC86B91C0ED06700972D0A /* EZSwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DC86B81C0ED06700972D0A /* EZSwiftExtensionsTests.swift */; };
@@ -55,6 +63,14 @@
 
 /* Begin PBXFileReference section */
 		31F868DA1C2B6E5E00542250 /* DoubleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtensions.swift; sourceTree = "<group>"; };
+		7605D3021C81FBB80046FAC3 /* EZSwiftExtensionsTestsArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsArray.swift; sourceTree = "<group>"; };
+		7605D3031C81FBB80046FAC3 /* EZSwiftExtensionsTestsBlockButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsBlockButton.swift; sourceTree = "<group>"; };
+		7605D3041C81FBB80046FAC3 /* EZSwiftExtensionsTestsBool.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsBool.swift; sourceTree = "<group>"; };
+		7605D3051C81FBB80046FAC3 /* EZSwiftExtensionsTestsCGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsCGFloat.swift; sourceTree = "<group>"; };
+		7605D3061C81FBB80046FAC3 /* EZSwiftExtensionsTestsDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsDictionary.swift; sourceTree = "<group>"; };
+		7605D3071C81FBB80046FAC3 /* EZSwiftExtensionsTestsInt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsInt.swift; sourceTree = "<group>"; };
+		7605D3081C81FBB80046FAC3 /* EZSwiftExtensionsTestsNSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsNSDate.swift; sourceTree = "<group>"; };
+		7605D3091C81FBB80046FAC3 /* EZSwiftExtensionsTestsString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftExtensionsTestsString.swift; sourceTree = "<group>"; };
 		B5DC86A91C0ED06700972D0A /* EZSwiftExtensions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EZSwiftExtensions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5DC86AC1C0ED06700972D0A /* EZSwiftExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EZSwiftExtensions.h; sourceTree = "<group>"; };
 		B5DC86AE1C0ED06700972D0A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -143,6 +159,14 @@
 		B5DC86B71C0ED06700972D0A /* EZSwiftExtensionsTests */ = {
 			isa = PBXGroup;
 			children = (
+				7605D3021C81FBB80046FAC3 /* EZSwiftExtensionsTestsArray.swift */,
+				7605D3031C81FBB80046FAC3 /* EZSwiftExtensionsTestsBlockButton.swift */,
+				7605D3041C81FBB80046FAC3 /* EZSwiftExtensionsTestsBool.swift */,
+				7605D3051C81FBB80046FAC3 /* EZSwiftExtensionsTestsCGFloat.swift */,
+				7605D3061C81FBB80046FAC3 /* EZSwiftExtensionsTestsDictionary.swift */,
+				7605D3071C81FBB80046FAC3 /* EZSwiftExtensionsTestsInt.swift */,
+				7605D3081C81FBB80046FAC3 /* EZSwiftExtensionsTestsNSDate.swift */,
+				7605D3091C81FBB80046FAC3 /* EZSwiftExtensionsTestsString.swift */,
 				B5DC86B81C0ED06700972D0A /* EZSwiftExtensionsTests.swift */,
 				B5DC86BA1C0ED06700972D0A /* Info.plist */,
 			);
@@ -333,7 +357,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7605D3161C81FC180046FAC3 /* EZSwiftExtensionsTestsDictionary.swift in Sources */,
+				7605D3141C81FC180046FAC3 /* EZSwiftExtensionsTestsBool.swift in Sources */,
+				7605D3131C81FC180046FAC3 /* EZSwiftExtensionsTestsBlockButton.swift in Sources */,
+				7605D3121C81FC180046FAC3 /* EZSwiftExtensionsTestsArray.swift in Sources */,
+				7605D3171C81FC180046FAC3 /* EZSwiftExtensionsTestsInt.swift in Sources */,
 				B5DC86B91C0ED06700972D0A /* EZSwiftExtensionsTests.swift in Sources */,
+				7605D3191C81FC180046FAC3 /* EZSwiftExtensionsTestsString.swift in Sources */,
+				7605D3151C81FC180046FAC3 /* EZSwiftExtensionsTestsCGFloat.swift in Sources */,
+				7605D3181C81FC180046FAC3 /* EZSwiftExtensionsTestsNSDate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
@@ -1,0 +1,43 @@
+//
+//  EZArrayExtensionsTests.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+@testable import EZSwiftExtensions
+
+class EZSwiftExtensionsTestsArray: XCTestCase {
+  
+    var numberArray: [Int] = []
+  
+    override func setUp() {
+        super.setUp()
+        numberArray = [Int](0...20)
+    }
+
+    func testIndexOf() {
+        XCTAssertEqual(numberArray.indexOf(10), numberArray.indexOfObject(10))
+    }
+  
+    func testRemoveObject() {
+        var copy = numberArray
+        copy.removeAtIndex(0)
+        numberArray.removeObject(0)
+        XCTAssertEqual(copy, numberArray)
+    }
+  
+    func testContainsInstanceOf() {
+        XCTAssertFalse(numberArray.containsInstanceOf("a"))
+        XCTAssertFalse(numberArray.containsInstanceOf(12.22))
+        XCTAssertTrue(numberArray.containsInstanceOf(46378))
+    }
+  
+    func testContainsArray() {
+        let array = [Int](2...6)
+        XCTAssertTrue(numberArray.containsArray(array))
+    }
+  
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsBlockButton.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsBlockButton.swift
@@ -1,0 +1,35 @@
+//
+//  EZSwiftExtensionsTestsBlockButton.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+@testable import EZSwiftExtensions
+
+class EZSwiftExtensionsTestsBlockButton: XCTestCase {
+  
+    var blockButton: BlockButton!
+
+    override func setUp() {
+        super.setUp()
+        blockButton = BlockButton()
+    }
+
+    func testHighlight() {
+        blockButton.highlight()
+        guard let _ = blockButton.action else {
+            XCTAssertNil(blockButton.highlightLayer)
+            return
+        }
+        XCTAssertNotNil(blockButton.highlightLayer)
+    }
+  
+    func testUnighlight() {
+        blockButton.unhighlight()
+        XCTAssertNil(blockButton.highlightLayer)
+    }
+
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsBool.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsBool.swift
@@ -1,0 +1,26 @@
+//
+//  EZSwiftExtensionsTestsBool.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+
+class EZSwiftExtensionsTestsBool: XCTestCase {
+  
+    var bool: Bool!
+
+    override func setUp() {
+        super.setUp()
+        bool = false
+    }
+
+    func testToggle() {
+        let value = bool
+        bool.toggle()
+        XCTAssertNotEqual(value, bool)
+    }
+
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsCGFloat.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsCGFloat.swift
@@ -1,0 +1,26 @@
+//
+//  EZSwiftExtensionsTestsCGFloat.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+
+class EZSwiftExtensionsTestsCGFloat: XCTestCase {
+  
+    var radians: CGFloat!
+    var degrees: CGFloat!
+  
+    override func setUp() {
+        super.setUp()
+        radians = CGFloat (M_PI * Double(2))
+        degrees = 360
+    }
+  
+    func testToggle() {
+        XCTAssertEqual(radians, degrees.degreesToRadians())
+    }
+  
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsDictionary.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsDictionary.swift
@@ -1,0 +1,28 @@
+//
+//  EZSwiftExtensionsTestsDictionary.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+
+class EZSwiftExtensionsTestsDictionary: XCTestCase {
+  
+    var dic: [String:Int]!
+    var secondDic: [String:Int]!
+  
+    override func setUp() {
+        super.setUp()
+        dic = ["one" : 1, "two" : 2, "three" : 3]
+        secondDic = ["four" : 4, "five" : 5]
+    }
+  
+    func testUnion() {
+        let union = dic.union(secondDic)
+        XCTAssertEqual(Array(dic.keys).count + Array(secondDic.keys).count, Array(union.keys).count)
+        XCTAssertEqual(Array(dic.values).count + Array(secondDic.values).count, Array(union.values).count)
+    }
+  
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsInt.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsInt.swift
@@ -1,0 +1,29 @@
+//
+//  EZSwiftExtensionsTestsInt.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+
+class EZSwiftExtensionsTestsInt: XCTestCase {
+  
+    var value: Int!
+  
+    override func setUp() {
+        super.setUp()
+        value = 64733
+    }
+  
+    func testDigits() {
+        XCTAssertEqual(value.digits, 5)
+    }
+  
+    func testConsistency() {
+        XCTAssertNotEqual(value.isEven, value.isOdd)
+        XCTAssertNotEqual(value.isPositive, value.isNegative)
+    }
+  
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsNSDate.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsNSDate.swift
@@ -1,0 +1,55 @@
+//
+//  EZSwiftExtensionsTestsNSDate.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+
+class EZSwiftExtensionsTestsNSDate: XCTestCase {
+  
+  //note that NSDate uses UTC in NSDate(timeIntervalSince1970: _)
+  
+    var string: String!
+    let format = "dd-mm-yyyy hh:mm:ss"
+  
+    override func setUp() {
+        super.setUp()
+        string = "01-01-1970 00:00:00"
+    }
+  
+    func testDateFromString() {
+        guard let dateFromString = NSDate(fromString: string, format: format) else {
+            XCTFail("Date From String Couldn't be initialized.")
+            return
+        }
+        XCTAssertEqualWithAccuracy(dateFromString.timeIntervalSince1970, 0, accuracy: 60 * 60 * 24)
+    }
+  
+    func testDateToString() {
+        let dateToString = NSDate(timeIntervalSince1970: 0).toStringUsingFormat(format)
+        guard let dateFromString = NSDate(fromString: dateToString, format: format) else {
+            XCTFail("Date From String Couldn't be initialized.")
+            return
+        }
+        XCTAssertEqualWithAccuracy(dateFromString.timeIntervalSince1970, 0, accuracy: 60 * 60 * 24)
+    }
+  
+    func testTimePassedBetweenDates() {
+        let date = NSDate(timeIntervalSince1970: 0)
+        XCTAssertTrue(date.timePassed().containsString("years"))
+        let now = NSDate()
+        XCTAssertTrue(now.timePassed().containsString("now") || now.timePassed().containsString("seconds"))
+    }
+  
+    func testComparable() {
+        let date = NSDate()
+        let future = NSDate(timeIntervalSinceNow: 1000)
+        XCTAssertTrue(date < future)
+        XCTAssertFalse(date > future)
+        XCTAssertTrue(date == date)
+    }
+  
+}

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsNSDate.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsNSDate.swift
@@ -29,7 +29,7 @@ class EZSwiftExtensionsTestsNSDate: XCTestCase {
     }
   
     func testDateToString() {
-        let dateToString = NSDate(timeIntervalSince1970: 0).toStringUsingFormat(format)
+        let dateToString = NSDate(timeIntervalSince1970: 0).toString(format: format)
         guard let dateFromString = NSDate(fromString: dateToString, format: format) else {
             XCTFail("Date From String Couldn't be initialized.")
             return

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
@@ -1,0 +1,78 @@
+//
+//  EZSwiftExtensionsTestsString.swift
+//  EZSwiftExtensions
+//
+//  Created by Valentino Urbano on 29/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+@testable import EZSwiftExtensions
+
+class EZSwiftExtensionsTestsString: XCTestCase {
+  
+    var string: String!
+
+    override func setUp() {
+        super.setUp()
+        string = "0123456789"
+    }
+
+    func testSubscript() {
+        XCTAssertEqual(string[2], "2")
+        XCTAssertEqual(string[9], "9")
+        XCTAssertEqual(string[0...9], "0123456789")
+        XCTAssertEqual(string[3..<5], "34")
+    }
+  
+    func testCapitalization() {
+        string = "lorem ipsum"
+        XCTAssertEqual(string.capitalizeFirst, "Lorem ipsum")
+    }
+    
+    func testIsOnlyEmptySpacesAndNewLineCharacters() {
+        let emptyString = " \n "
+        XCTAssertFalse(string.isOnlyEmptySpacesAndNewLineCharacters())
+        XCTAssertTrue(emptyString.isOnlyEmptySpacesAndNewLineCharacters())
+    }
+    
+    func testTrim() {
+        string = "space space"
+        let trimmed = string.trim()
+        XCTAssertFalse(trimmed.containsString(" "))
+    }
+    
+    func testIsEmail() {
+        XCTAssertFalse(string.isEmail)
+        string = "test@test.com"
+        XCTAssertTrue(string.isEmail)
+        string = "test@test"
+        XCTAssertFalse(string.isEmail)
+        string = "test@test."
+        XCTAssertFalse(string.isEmail)
+        string = "1@1.1"
+        XCTAssertFalse(string.isEmail)
+    }
+    
+    func testExtractURLs() {
+        string = "http://google.com http fpt:// http://facebook.com test"
+        let urls = string.extractURLs
+        XCTAssertEqual(urls.count, 2)
+    }
+    
+    func testContains() {
+        XCTAssertTrue(string.contains("01"))
+        XCTAssertTrue(string.contains("01", compareOption: NSStringCompareOptions.AnchoredSearch))
+        XCTAssertFalse(string.contains("12", compareOption: NSStringCompareOptions.AnchoredSearch))
+        XCTAssertFalse(string.contains("h"))
+    }
+    
+    func testConversions() {
+        XCTAssertNotNil(string.toInt())
+        string = "0.12"//Assumed USA locale, change to "," if EU
+        XCTAssertNotNil(string.toDouble())
+        XCTAssertNotNil(string.toFloat())
+        XCTAssertTrue(string.toNSString.isKindOfClass(NSString.self))
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -34,11 +34,22 @@ if UIInterfaceOrientationIsPortrait(ez.screenOrientation) {
 }
 ```
 
-Easily access your screen width & height:
+
+Easily access your screen orientation:
 
 ``` swift
-print(ez.screenWidth) // 375.0 on iPhone6
-print(ez.screenHeight) // 667.0 on iPhone6
+if UIInterfaceOrientationIsPortrait(ez.screenOrientation) {
+  // Screen orientation is portrait
+} else {
+  // Screen orientation is not portrait
+}
+```
+
+Easily access your screen traitCollections:
+
+``` swift
+print(ez.verticalSizeClass) // regular on iPhone6
+print(ez.horizontalSizeClass) // compact  on iPhone6
 ```
 Easily access your status bar height:
 

--- a/Sources/CGFloatExtensions.swift
+++ b/Sources/CGFloatExtensions.swift
@@ -11,12 +11,23 @@ import UIKit
 extension CGFloat {
     /// EZSwiftExtensions
     public var center: CGFloat { return (self / 2) }
+  
+    /// EZSwiftExtensions
+    public func toRadians() -> CGFloat {
+        return (CGFloat (M_PI) * self) / 180.0
+    }
+  
+    /// EZSwiftExtensions
+    public func degreesToRadians() -> CGFloat {
+        return toRadians()
+    }
+  
+    /// EZSwiftExtensions
+    public mutating func toRadiansInPlace() {
+        self = (CGFloat (M_PI) * self) / 180.0
+    }
 }
 
-/// EZSwiftExtensions
-public func degreesToRadians (angle: CGFloat) -> CGFloat {
-    return (CGFloat (M_PI) * angle) / 180.0
-}
 
 
 

--- a/Sources/EZSwiftExtensions.swift
+++ b/Sources/EZSwiftExtensions.swift
@@ -50,6 +50,16 @@ public struct ez {
     public static var screenOrientation: UIInterfaceOrientation {
         return UIApplication.sharedApplication().statusBarOrientation
     }
+  
+    /// EZSwiftExtensions
+    public static var horizontalSizeClass : UIUserInterfaceSizeClass {
+      return self.topMostVC?.traitCollection.horizontalSizeClass ?? UIUserInterfaceSizeClass(rawValue: 0)!
+    }
+  
+    /// EZSwiftExtensions
+    public static var verticalSizeClass : UIUserInterfaceSizeClass {
+      return self.topMostVC?.traitCollection.verticalSizeClass ?? UIUserInterfaceSizeClass(rawValue: 0)!
+    }
 
     /// EZSwiftExtensions
     public static var screenWidth: CGFloat {

--- a/Sources/NSDateExtensions.swift
+++ b/Sources/NSDateExtensions.swift
@@ -27,7 +27,14 @@ extension NSDate {
         formatter.timeStyle = NSDateFormatterStyle.MediumStyle
         return formatter.stringFromDate(self)
     }
-    
+  
+    /// EZSwiftExtensions
+    public func toStringUsingFormat(format: String) -> String {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = format
+        return formatter.stringFromDate(self)
+      }
+  
     /// EZSwiftExtensions
     public func daysInBetweenDate(date: NSDate) -> Double {
         var diff = self.timeIntervalSinceNow - date.timeIntervalSinceNow
@@ -90,11 +97,13 @@ extension NSDate {
 extension NSDate: Comparable {}
 
 public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs.isEqualToDate(rhs)
+  return lhs.isEqualToDate(rhs)
 }
 
 public func <(lhs: NSDate, rhs: NSDate) -> Bool {
     return lhs.compare(rhs) == .OrderedAscending
 }
 
-
+public func >(lhs: NSDate, rhs: NSDate) -> Bool {
+  return lhs.compare(rhs) == .OrderedDescending
+}

--- a/Sources/NSObjectExtentions.swift
+++ b/Sources/NSObjectExtentions.swift
@@ -14,11 +14,7 @@ extension NSObject {
     }
     
     public static var className: String {
-        return stringFromClass(self)
+        return String(self)
     }
 
-}
-
-public func stringFromClass(aClass: AnyClass) -> String {
-    return NSStringFromClass(aClass).componentsSeparatedByString(".").last!
 }

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -43,8 +43,13 @@ extension String {
     }
     
     /// EZSwiftExtensions - Trims white space and new line characters
-    public mutating func trim() {
-         self = self.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+    public mutating func trimInPlace() {
+         self = self.trim()
+    }
+    
+    /// EZSwiftExtensions
+    public func trim() -> String {
+        return self.componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()).joinWithSeparator("")
     }
     
     /// EZSwiftExtensions

--- a/Sources/UIUserInterfaceSizeClassExtensions.swift
+++ b/Sources/UIUserInterfaceSizeClassExtensions.swift
@@ -1,0 +1,24 @@
+//
+//  UIUserInterfaceSizeClassExtensions.swift
+//  EZSwiftExtensionsExample
+//
+//  Created by Valentino Urbano on 28/01/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIUserInterfaceSizeClass {
+  /// EZSwiftExtensions
+  public var stringValue: String {
+    switch self.rawValue {
+    case 1:
+      return "Compact"
+    case 2:
+      return "Regular"
+    default:
+      return "Unspecified"
+    }
+  }
+}

--- a/Sources/UIViewExtensions.swift
+++ b/Sources/UIViewExtensions.swift
@@ -237,7 +237,7 @@ extension UIView {
     public func setRotationX(x: CGFloat) {
         var transform = CATransform3DIdentity
         transform.m34 = 1.0 / -1000.0
-        transform = CATransform3DRotate(transform, degreesToRadians(x), 1.0, 0.0, 0.0)
+        transform = CATransform3DRotate(transform, x.degreesToRadians(), 1.0, 0.0, 0.0)
         self.layer.transform = transform
     }
     
@@ -245,7 +245,7 @@ extension UIView {
     public func setRotationY(y: CGFloat) {
         var transform = CATransform3DIdentity
         transform.m34 = 1.0 / -1000.0
-        transform = CATransform3DRotate(transform, degreesToRadians(y), 0.0, 1.0, 0.0)
+        transform = CATransform3DRotate(transform, y.degreesToRadians(), 0.0, 1.0, 0.0)
         self.layer.transform = transform
     }
     
@@ -253,7 +253,7 @@ extension UIView {
     public func setRotationZ(z: CGFloat) {
         var transform = CATransform3DIdentity
         transform.m34 = 1.0 / -1000.0
-        transform = CATransform3DRotate(transform, degreesToRadians(z), 0.0, 0.0, 1.0)
+        transform = CATransform3DRotate(transform, z.degreesToRadians(), 0.0, 0.0, 1.0)
         self.layer.transform = transform
     }
     
@@ -261,9 +261,9 @@ extension UIView {
     public func setRotation(x x: CGFloat, y: CGFloat, z: CGFloat) {
         var transform = CATransform3DIdentity
         transform.m34 = 1.0 / -1000.0
-        transform = CATransform3DRotate(transform, degreesToRadians(x), 1.0, 0.0, 0.0)
-        transform = CATransform3DRotate(transform, degreesToRadians(y), 0.0, 1.0, 0.0)
-        transform = CATransform3DRotate(transform, degreesToRadians(z), 0.0, 0.0, 1.0)
+        transform = CATransform3DRotate(transform, x.degreesToRadians(), 1.0, 0.0, 0.0)
+        transform = CATransform3DRotate(transform, y.degreesToRadians(), 0.0, 1.0, 0.0)
+        transform = CATransform3DRotate(transform, z.degreesToRadians(), 0.0, 0.0, 1.0)
         self.layer.transform = transform
     }
     


### PR DESCRIPTION
**Note:** I feel like 3 different commits for all the different areas changed is better, but if you prefer just one commit for everything that's fine too. Just let me know.

I've added test cases for most of the project and changed a few things (listed below), it's just one commit for now, let me know if you'd prefer to have one commit for the tests and one for the rest.

It's pretty large change to I'm open to discussions / rolling back a few things if you feel like they're out of place.

#UnitTests

I've written the UnitTests for most of the extensions, there are still a few missing but let's say 80/90% done.


Added for:
- Dictionary
- Int
- NSDate
- String
- Array
- BlockButton
- Bool
- CGFloat

#Changes

##NSDate

I've added an API for specifying your own format for  `dateFromString`, same deal for `toStringUsingFormat`. Added the operator `>` and fixed the `==` to use the NSDate specific `isEqualTo`.

##NSObject

Swift [recently added](https://www.natashatherobot.com/nsstringfromclass-in-swift/) `String(className)` to the language so we don't need to use the bridging for that anymore.

##String

Trimming didn't work, changed it to [this](http://stackoverflow.com/questions/5581141/stringbytrimmingcharactersinset-is-not-removing-characters-in-the-middle-of-the/26152034#26152034) and added a non mutating function as well to do the same.

##ez Struct

Added `verticalSizeClass` and `horizontalSizeClass` for the top ViewController (defaults to Unspecified if it's not set yet). Also added a `.stringValue` to `UIUserInterfaceSizeClass` for easier comprehension and debugging.
