### PR TITLE
(UIColor) Updated init method in UIColor with default alpha = 1

### DIFF
--- a/Sources/UIColorExtensions.swift
+++ b/Sources/UIColorExtensions.swift
@@ -9,13 +9,8 @@ import UIKit
 
 extension UIColor {
     
-    /// EZSwiftExtensions
-    public convenience init(r: CGFloat, g: CGFloat, b: CGFloat) {
-        self.init(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: 1)
-    }
-    
-    /// EZSwiftExtensions
-    public convenience init(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+    /// EZSE: init method with RGB values from 0 to 255, instead of 0 to 1
+    public convenience init(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat = 1) {
         self.init(red: r / 255.0, green: g / 255.0, blue: b / 255.0, alpha: a)
     }
 


### PR DESCRIPTION
Instead of having 2 methods, we can put a: CGFloat **= 1**