### PR TITLE
Fixed containsInstanceOf() example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Easily check if an array contains instance of an object:
 
 ``` swift
 var myArray = ["charmander","bulbasaur","squirtle"]
-print(myArray.containsInstanceOf("hey")) // true
+print(myArray.containsInstanceOf("charmander")) // true
 print(myArray.containsInstanceOf(1)) // false
 ```
 


### PR DESCRIPTION
print(myArray.containsInstanceOf("hey")) should be **false** because "hey" isn't inside the array.
To make it true, needs to be a pokemon, like "charmander"