### PR TITLE
Int autoConvert()

### DIFF
--- a/EZSwiftExtensions/IntAutoConvertExtension.swift
+++ b/EZSwiftExtensions/IntAutoConvertExtension.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+protocol InitializableFromInt {
+    init(_ value: Int)
+}
+
+extension Int {
+    /// Automatically converts an `Int` to the right type.
+    func autoConvert<T: InitializableFromInt>() -> T {
+        return T(self)
+    }
+}
+
+// MARK: - FloatingPointType
+extension Double: InitializableFromInt { }
+
+extension Float: InitializableFromInt { }
+
+extension CGFloat: InitializableFromInt { }
+
+// MARK: - SignedIntegerType
+extension Int8: InitializableFromInt { }
+
+extension Int32: InitializableFromInt { }
+
+extension Int64: InitializableFromInt { }
+
+// MARK: - BooleanType
+extension Bool: InitializableFromInt {
+    init(_ value: Int) {
+        self = value != 0
+    }
+}

--- a/EZSwiftExtensionsExample.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensionsExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C85840ED1C43B05200595696 /* NSURLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85840EC1C43B05200595696 /* NSURLExtensions.swift */; };
+		DEF463C31C7ECB6000EC0856 /* IntAutoConvertExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF463C21C7ECB6000EC0856 /* IntAutoConvertExtension.swift */; };
 		E1839DB91BF79335002212C6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1839DB81BF79335002212C6 /* AppDelegate.swift */; };
 		E1839DBB1BF79335002212C6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1839DBA1BF79335002212C6 /* ViewController.swift */; };
 		E1839DBE1BF79335002212C6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E1839DBC1BF79335002212C6 /* Main.storyboard */; };
@@ -46,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		C85840EC1C43B05200595696 /* NSURLExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSURLExtensions.swift; path = Sources/NSURLExtensions.swift; sourceTree = SOURCE_ROOT; };
+		DEF463C21C7ECB6000EC0856 /* IntAutoConvertExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntAutoConvertExtension.swift; sourceTree = "<group>"; };
 		E1839DB51BF79335002212C6 /* EZSwiftExtensionsExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EZSwiftExtensionsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1839DB81BF79335002212C6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = EZSwiftExtensionsExample/AppDelegate.swift; sourceTree = SOURCE_ROOT; };
 		E1839DBA1BF79335002212C6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = EZSwiftExtensionsExample/ViewController.swift; sourceTree = SOURCE_ROOT; };
@@ -109,6 +111,7 @@
 				E1839E0A1BF79974002212C6 /* BoolExtentions.swift */,
 				E1839E0B1BF79974002212C6 /* CGFloatExtensions.swift */,
 				E1839E0C1BF79974002212C6 /* CGRectExtensions.swift */,
+				DEF463C21C7ECB6000EC0856 /* IntAutoConvertExtension.swift */,
 				E1839E0D1BF79974002212C6 /* DictionaryExtensions.swift */,
 				E1CB3C1B1C25FFA000DF77CD /* DoubleExtensions.swift */,
 				E1839E0E1BF79974002212C6 /* EZSwiftExtensions.swift */,
@@ -259,6 +262,7 @@
 				E1CB3C1C1C25FFA000DF77CD /* DoubleExtensions.swift in Sources */,
 				E1839E341BF79974002212C6 /* UIImageExtensions.swift in Sources */,
 				E1839E241BF79974002212C6 /* BlockTap.swift in Sources */,
+				DEF463C31C7ECB6000EC0856 /* IntAutoConvertExtension.swift in Sources */,
 				E1839E1F1BF79974002212C6 /* BlockButton.swift in Sources */,
 				E1839E311BF79974002212C6 /* UIColorExtensions.swift in Sources */,
 				E1839E251BF79974002212C6 /* BlockWebView.swift in Sources */,

--- a/Sources/UIImageExtensions.swift
+++ b/Sources/UIImageExtensions.swift
@@ -79,20 +79,20 @@ extension UIImage {
         return croppedImage
     }
 
-}
 
-///EZSE: Returns the image associated with the URL
-public convenience init?(urlString:String) {
-    guard let url = NSURL(string: urlString) else
-    {
-        self.init(data:NSData())
-        return
+    ///EZSE: Returns the image associated with the URL
+    public convenience init?(urlString:String) {
+        guard let url = NSURL(string: urlString) else
+        {
+            self.init(data:NSData())
+            return
+        }
+        guard let data = NSData(contentsOfURL: url) else
+        {
+            print("EZSE: No image in URL")
+            self.init(data:NSData())
+            return
+        }
+        self.init(data:data)
     }
-    guard let data = NSData(contentsOfURL: url) else
-    {
-        print("EZSE: No image in URL")
-        self.init(data:NSData())
-        return
-    }
-    self.init(data:data)
 }


### PR DESCRIPTION
## TLDR; `myInt.autoConvert()`
#### Automatically convert your `Int` to whatever type is initializable from `Int` with just one function! 
For example:
```
let myInt = 42
let myDouble: Double = myInt.autoConvert()
let myCGFloat: CGFloat = myInt.autoConvert()
let myFloat: Float = myInt.autoConvert()
let myBool: Bool = myInt.autoConvert()
```
- Saves you time from having to figure out which `.toSomeType` you have to choose.
- Saves you time from having to migrate the code when some type constraint related to `Int` conversion changes in a way that makes your code incompatible

Note: This is meant to be used side-by-side with `.toSomeType` functions since `.toSomeType` is really powerful in circumstances where the type cannot be inferred by `.autoConvert()`

Btw, If you think it's going to result in longer code because you'd have to declare the type, please read the "Longer Explanation" section to see the rationale.

## Longer explanation
Let's say you have this awesome function from an awesome library:
```
func doAwesomeStuff(number: CGFloat)
```

And since you're using integer all over the app, what you do this `doAwesomeStuff(myInt.toCGFloat)` everywhere


However, one day, the awesome library owner decided to change the function definition to this:
```
func doAwesomeStuff(number: Double)
```
Now you have to go to all `doAwesomeStuff` calls you did that involves an `Int` and change
`doAwesomeStuff(myInt.toCGFloat)` to `doAwesomeStuff(myInt.toDouble)`. While it might not be that time consuming for smaller apps, this could be a reason for larger, math heavy apps to not migrate to the newer versions of that awesome library.

#### Good news
`doAwesomeStuff(myInt.autoConvert())` will be suitable for both the version of the library. `.autoConvert()` lets the compiler (as opposed to you) choose which `.toSomeType` function is best so you don't have to change a single line of code during this migration.

## Pros and cons
### Pros
- Don't have to think about which `.toSomeType` function to choose.
- More robust to changes related to type conversion.

### Cons
- When the type is not defined yet, it'll result in a longer code. For example: `let myDouble = myInt.toDouble` vs.  `let myDouble: Double = myInt.autoConvert()`

### Ideas for Future Improvements
- Add more auto-convertible types. (e.g. Add `.autoConvert()` for `Double`)
- Auto convert functions! (e.g. `let integerDoAwesomeStuff = autoConvert(floatDoAwesomeStuff)`

Feel free to add more suggestions, pros and cons, etc!