### PR TITLE
Add missing tests for Array extensions. Make each public again with t…

### DIFF
--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
@@ -63,4 +63,71 @@ class EZSwiftExtensionsTestsArray: XCTestCase {
         XCTAssertNotNil(numberArray.random())
         XCTAssertNil([].random())
     }
+
+	func testTestAll() {
+		XCTAssertTrue(numberArray.testAll { $0 < 10 })
+	}
+
+	func testGet() {
+		XCTAssertNotNil(numberArray.get(1))
+		XCTAssertNil(numberArray.get(10))
+	}
+
+	func testReverseIndex() {
+		let array = [Int](0...5)
+		XCTAssertEqual(array.reverseIndex(0), 5)
+		XCTAssertEqual(array.reverseIndex(2), 3)
+	}
+
+	func testTakeMax() {
+		XCTAssertEqual(numberArray.takeMax(2).count, 2)
+	}
+
+	func testEach() {
+		var sameArray: [Int] = []
+		numberArray.each { sameArray.append($0) }
+		XCTAssertEqual(numberArray, sameArray)
+
+		var indexArray: [Int] = []
+		numberArray.each { indexArray.append($0.0) }
+		XCTAssertEqual(indexArray, [Int](0..<numberArray.count))
+	}
+
+	func testMapFilter() {
+		let filtered = numberArray.mapFilter { number -> String? in
+			return number == 1 ? String(number) : nil
+		}
+
+		XCTAssertEqual(filtered.count, 2)
+	}
+
+	func testUnion() {
+		let a = [Int](0...2), b = [Int](3...5), c = [Int](6...8)
+		let union = a.union(b, c)
+
+		XCTAssertEqual(union, [Int](0...8))
+	}
+
+	func testIntersection() {
+		let a = [Int](0...8), b = [Int](3...4), c = [Int](1...6)
+		let intersection = a.intersection(b, c)
+
+		XCTAssertEqual(intersection, [3, 4])
+	}
+
+	func testDifference() {
+		let a = [Int](0...8), b = [Int](3...4), c = [Int](1...2)
+		let difference = a.difference(b, c)
+
+		XCTAssertEqual(difference, [0, 5, 6, 7, 8])
+	}
+
+	func testOptionalEquatable() {
+		let a: [Int]? = [1, 2, 3]
+		let b: [Int]? = [1, 2, 3]
+		let c: [Int]? = nil
+
+		XCTAssertTrue(a == b)
+		XCTAssertFalse(a == c)
+	}
 }

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -54,17 +54,15 @@ extension Array {
         return Array(self[0..<Swift.max(0, Swift.min(n, count))])
     }
     
-    //TODO: Remove this
     /// EZSE: Iterates on each element of the array.
-    private func each(call: (Element) -> ()) {
+    public func each(call: (Element) -> ()) {
         for item in self {
             call(item)
         }
     }
     
-    //TODO: Remove this
     /// EZSE: Iterates on each element of the array with its index.
-    private func each(call: (Int, Element) -> ()) {
+    public func each(call: (Int, Element) -> ()) {
         for (index, item) in self.enumerate() {
             call(index, item)
         }

--- a/Sources/EZSwiftExtensions.swift
+++ b/Sources/EZSwiftExtensions.swift
@@ -186,19 +186,6 @@ public struct ez {
 
     /// EZSE: 
     private static func requestURL(url: String, success: (NSData?) -> Void, error: ((NSError) -> Void)? = nil) {
-        guard #available(iOS 9, *) else {
-            NSURLConnection.sendAsynchronousRequest(
-                NSURLRequest(URL: NSURL (string: url)!),
-                queue: NSOperationQueue.mainQueue(),
-                completionHandler: { response, data, err in
-                    if let e = err {
-                        error?(e)
-                    } else {
-                        success(data)
-                    }
-            })
-            return
-        }
         NSURLSession.sharedSession().dataTaskWithRequest(
             NSURLRequest(URL: NSURL (string: url)!),
             completionHandler: { data, response, err in


### PR DESCRIPTION
Hey man,
I've added tests for the Array extensions. Both `each` methods are now testable so you can see how they work and we can (hopefully) bring them back as `public` to be of use. They're probably the most used methods for us. Type inference is really the key here, making the intend clear with less typing ;)

- Add missing tests for Array extensions. 
- Make each public again with tests. 
- Remove use of deprecated method.

I'll work on the Dictionary extensions next.