### PR TITLE
Use Swift 2.2-approved selector syntax

### DIFF
--- a/Sources/BlockButton.swift
+++ b/Sources/BlockButton.swift
@@ -56,9 +56,9 @@ public class BlockButton: UIButton {
     }
     
     private func defaultInit() {
-        addTarget(self, action: "didPressed:", forControlEvents: UIControlEvents.TouchUpInside)
-        addTarget(self, action: "highlight", forControlEvents: [UIControlEvents.TouchDown, UIControlEvents.TouchDragEnter])
-        addTarget(self, action: "unhighlight", forControlEvents: [UIControlEvents.TouchUpInside, UIControlEvents.TouchUpOutside, UIControlEvents.TouchCancel, UIControlEvents.TouchDragExit])
+        addTarget(self, action: #selector(BlockButton.didPressed(_:)), forControlEvents: UIControlEvents.TouchUpInside)
+        addTarget(self, action: #selector(BlockButton.highlight), forControlEvents: [UIControlEvents.TouchDown, UIControlEvents.TouchDragEnter])
+        addTarget(self, action: #selector(BlockButton.unhighlight), forControlEvents: [UIControlEvents.TouchUpInside, UIControlEvents.TouchUpOutside, UIControlEvents.TouchCancel, UIControlEvents.TouchDragExit])
         setTitleColor(UIColor.blackColor(), forState: UIControlState.Normal)
         setTitleColor(UIColor.blueColor(), forState: UIControlState.Selected)
     }

--- a/Sources/BlockLongPress.swift
+++ b/Sources/BlockLongPress.swift
@@ -19,7 +19,7 @@ public class BlockLongPress: UILongPressGestureRecognizer {
     public convenience init (action: ((UILongPressGestureRecognizer) -> Void)?) {
         self.init()
         longPressAction = action
-        addTarget(self, action: "didLongPressed:")
+        addTarget(self, action: #selector(BlockLongPress.didLongPressed(_:)))
     }
     
     public func didLongPressed(longPress: UILongPressGestureRecognizer) {

--- a/Sources/BlockPan.swift
+++ b/Sources/BlockPan.swift
@@ -19,7 +19,7 @@ public class BlockPan: UIPanGestureRecognizer {
     public convenience init (action: ((UIPanGestureRecognizer) -> Void)?) {
         self.init()
         self.panAction = action
-        self.addTarget(self, action: "didPan:")
+        self.addTarget(self, action: #selector(BlockPan.didPan(_:)))
     }
     
     public func didPan (pan: UIPanGestureRecognizer) {

--- a/Sources/BlockPinch.swift
+++ b/Sources/BlockPinch.swift
@@ -19,7 +19,7 @@ public class BlockPinch: UIPinchGestureRecognizer {
     public convenience init (action: ((UIPinchGestureRecognizer) -> Void)?) {
         self.init()
         self.pinchAction = action
-        self.addTarget(self, action: "didPinch:")
+        self.addTarget(self, action: #selector(BlockPinch.didPinch(_:)))
     }
     
     public func didPinch (pinch: UIPinchGestureRecognizer) {

--- a/Sources/BlockSwipe.swift
+++ b/Sources/BlockSwipe.swift
@@ -23,7 +23,7 @@ public class BlockSwipe: UISwipeGestureRecognizer {
             self.direction = direction
             numberOfTouchesRequired = fingerCount
             swipeAction = action
-            addTarget(self, action: "didSwipe:")
+            addTarget(self, action: #selector(BlockSwipe.didSwipe(_:)))
     }
     
     public func didSwipe (swipe: UISwipeGestureRecognizer) {

--- a/Sources/BlockTap.swift
+++ b/Sources/BlockTap.swift
@@ -24,7 +24,7 @@ public class BlockTap: UITapGestureRecognizer {
             self.numberOfTapsRequired = tapCount
             self.numberOfTouchesRequired = fingerCount
             self.tapAction = action
-            self.addTarget(self, action: "didTap:")
+            self.addTarget(self, action: #selector(BlockTap.didTap(_:)))
     }
     
     public func didTap (tap: UITapGestureRecognizer) {

--- a/Sources/UIViewControllerExtensions.swift
+++ b/Sources/UIViewControllerExtensions.swift
@@ -24,19 +24,19 @@ extension UIViewController {
     }
     
     public func addKeyboardWillShowNotification() {
-        self.addNotificationObserver(UIKeyboardWillShowNotification, selector: "keyboardWillShowNotification:");
+        self.addNotificationObserver(UIKeyboardWillShowNotification, selector: #selector(UIViewController.keyboardWillShowNotification(_:)));
     }
     
     public func addKeyboardDidShowNotification() {
-        self.addNotificationObserver(UIKeyboardDidShowNotification, selector: "keyboardDidShowNotification:");
+        self.addNotificationObserver(UIKeyboardDidShowNotification, selector: #selector(UIViewController.keyboardDidShowNotification(_:)));
     }
     
     public func addKeyboardWillHideNotification() {
-        self.addNotificationObserver(UIKeyboardWillHideNotification, selector: "keyboardWillHideNotification:");
+        self.addNotificationObserver(UIKeyboardWillHideNotification, selector: #selector(UIViewController.keyboardWillHideNotification(_:)));
     }
     
     public func addKeyboardDidHideNotification() {
-        self.addNotificationObserver(UIKeyboardDidHideNotification, selector: "keyboardDidHideNotification:");
+        self.addNotificationObserver(UIKeyboardDidHideNotification, selector: #selector(UIViewController.keyboardDidHideNotification(_:)));
     }
     
     public func removeKeyboardWillShowNotification() {
@@ -105,7 +105,7 @@ extension UIViewController {
     
     //EZSE: Makes the UIViewController register tap events and hides keyboard when clicked somewhere in the ViewController. 
     public func hideKeyboardWhenTappedAround() {
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: "dismissKeyboard")
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
         view.addGestureRecognizer(tap)
     }
     


### PR DESCRIPTION
This fixes the warnings on the new version of Xcode.