### PR TITLE
Add convenience method for a dismiss button to UITextView extension

### DIFF
--- a/Sources/UITextViewExtensions.swift
+++ b/Sources/UITextViewExtensions.swift
@@ -27,4 +27,20 @@ extension UITextView {
         editable = false
         scrollEnabled = false
     }
+    
+    /// EZSwiftExtensions: Automatically adds a toolbar with a done button to the top of the keyboard. 
+    /// Tapping the button will dismiss the keyboard.
+    func addDoneButton(barStyle: UIBarStyle = .Default) {
+        
+        let keyboardToolbar = UIToolbar()
+        keyboardToolbar.items = [
+            UIBarButtonItem(barButtonSystemItem: .FlexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: "Done", style: .Done, target: self, action: #selector(resignFirstResponder))
+        ]
+        
+        keyboardToolbar.barStyle = barStyle
+        keyboardToolbar.sizeToFit()
+        
+        inputAccessoryView = keyboardToolbar
+    }
 }


### PR DESCRIPTION
With this method it's possible to add a toolbar with a done button to UITextView's keyboard with one line of code. 

Example:
```
class ViewController: UIViewController {
    @IBOutlet var textView: UITextView!

    override func viewDidLoad() {
        super.viewDidLoad()

        textView.addDoneButton()
    }
}
```

![simulator screen shot 08 apr 2016 23 01 37](https://cloud.githubusercontent.com/assets/11836793/14384341/e40fee8c-fddd-11e5-8a5f-23b996c35395.png)

I used this little extension in a lot of projects by now and thought of sharing it. 