### PR TITLE
Swift NSDate extension with nullable convenience init crashes EXC_BAD_ACCESS

### DIFF
--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsNSDate.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsNSDate.swift
@@ -12,11 +12,13 @@ class EZSwiftExtensionsTestsNSDate: XCTestCase {
     // note that NSDate uses UTC in NSDate(timeIntervalSince1970: _)
 
     var string: String!
+    var wrongDateString: String!
     let format = "dd-mm-yyyy hh:mm:ss"
 
     override func setUp() {
         super.setUp()
         string = "01-01-1970 00:00:00"
+        wrongDateString = "13-82-1900 90:65:12"
     }
 
     func testDateFromString() {
@@ -25,6 +27,7 @@ class EZSwiftExtensionsTestsNSDate: XCTestCase {
             return
         }
         XCTAssertEqualWithAccuracy(dateFromString.timeIntervalSince1970, 0, accuracy: 60 * 60 * 24)
+        XCTAssertNil(NSDate(fromString: wrongDateString, format: format), "Date From String initialized, but source string was invalid.")
     }
 
     func testDateToString() {

--- a/Sources/NSDateExtensions.swift
+++ b/Sources/NSDateExtensions.swift
@@ -15,6 +15,7 @@ extension NSDate {
         if let date = formatter.dateFromString(string) {
             self.init(timeInterval: 0, sinceDate: date)
         } else {
+            self.init()
             return nil
         }
     }


### PR DESCRIPTION
Just got a situation when user enters date via string in my application, then I pass entered string in NSDate(fromString:format:) and estimate to get nil if it isn't valid, however I got EXC_BAD_ACCESS. I went to stackoverflow and found that it's a problem for new xcode 7.3.

http://stackoverflow.com/questions/36189714/new-xcode-7-3-swift-nsdate-extension-with-nullable-convenience-init-crashes-exc

I also added a test case for creating NSDate from invalid string. I don't know should we have one now, but if we had, then we could find this error earlier.