### PR TITLE
UIStoryboard extension for easily instantiating view controllers

### DIFF
--- a/Sources/UIStoryboardExtensions.swift
+++ b/Sources/UIStoryboardExtensions.swift
@@ -14,4 +14,12 @@ public extension UIStoryboard {
         let bundle = NSBundle.mainBundle()
         return UIStoryboard(name: bundle.objectForInfoDictionaryKey("UIMainStoryboardFile") as! String, bundle: bundle)
     }
+
+    /// EZSE: Get view controller from storyboard by its class type
+    /// Usage: let profileVC = storyboard!.instantiateVC(ProfileViewController) /* profileVC is of type ProfileViewController */
+    /// Warning: identifier should match storyboard ID in storyboard of identifier class
+    public func instantiateVC<T>(identifier: T.Type) -> T {
+        let storyboardID = String(identifier)
+        return instantiateViewControllerWithIdentifier(storyboardID) as! T
+    }
 }


### PR DESCRIPTION
Creating view controllers from code using storyboards is a lot of boilerplate.

From
let vcName = ViewController.className;
let vc = storyboard!.instantiateViewControllerWithIdentifier(vcName) as! ViewController

To
let vc = storyboard!.instantiateVC(ViewController)

Both vc are of type ViewController.

