### PR TITLE
Change "panned" to "pinched" in print call

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,7 +827,7 @@ mainview.addPinchGesture { (pinch) -> () in
 // OR    
 mainview.addPinchGesture(target: self, action: "userAction")
 func userAction() {
-	print("panned")
+	print("pinched")
 }
 ```
 ``` swift      

--- a/Sources/NSURLExtensions.swift
+++ b/Sources/NSURLExtensions.swift
@@ -80,7 +80,7 @@ extension NSURL {
         return true
     }
 
-    /// EZSE: Returns true of given file is a directory
+    /// EZSE: Returns true if given file is a directory
     public var fileIsDirectory: Bool {
         var isdirv: AnyObject?
         do {
@@ -127,7 +127,7 @@ extension NSURL {
         }
     }
 
-    /// EZSE: Returns last file access date, nil if file doesn't exist or didn't accessed yet
+    /// EZSE: Returns last file access date, nil if file doesn't exist or not yet accessed
     public var fileAccessDate: NSDate? {
         NSURLCustomIconKey
         var dateaccessv: AnyObject?
@@ -148,7 +148,7 @@ extension NSURL {
         return sizev?.longLongValue ?? -1
     }
 
-    /// EZSE: File is hidden or not, don't care about files begining with dot
+    /// EZSE: File is hidden or not, don't care about files beginning with dot
     public var fileIsHidden: Bool {
         get {
             var ishiddenv: AnyObject?
@@ -167,7 +167,7 @@ extension NSURL {
         }
     }
 
-    /// EZSE: Checks file is writable
+    /// EZSE: Checks if file is writable
     public var fileIsWritable: Bool {
         var isdirv: AnyObject?
         do {


### PR DESCRIPTION
In an example of the mainview.addPinchGesture(target: self, action: "userAction") call, the print() statement had been copied down from the addPanGesture() call above, and not changed to reflect the new functionality.