### PR TITLE
capitalize(d)Prefix + capitalize(d)Suffix + tests

### DIFF
--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
@@ -30,6 +30,26 @@ class EZSwiftExtensionsTestsString: XCTestCase {
         string = "eZSwiftExtensions"
         string.capitalizeFirst()
         XCTAssertEqual(string, "EZSwiftExtensions")
+
+        string = "ezswiftExtensions"
+        XCTAssertEqual(string.capitalizedPrefix(5), "EZSWIftExtensions")
+        string.capitalizePrefix(3)
+        XCTAssertEqual(string, "EZSwiftExtensions")
+        string = "ez swift extensions"
+        XCTAssertEqual(string.capitalizedPrefix(string.length + 1), "EZ SWIFT EXTENSIONS")
+        XCTAssertEqual(string, "ez swift extensions")
+        string.capitalizePrefix(string.length + 14)
+        XCTAssertEqual(string, "EZ SWIFT EXTENSIONS")
+
+        string = "ezswiftExtensions"
+        XCTAssertEqual(string.capitalizedSuffix(6), "ezswiftExteNSIONS")
+        string.capitalizeSuffix(4)
+        XCTAssertEqual(string, "ezswiftExtensIONS")
+        string = "ez swift extensions"
+        XCTAssertEqual(string.capitalizedSuffix(string.length + 1), "EZ SWIFT EXTENSIONS")
+        XCTAssertEqual(string, "ez swift extensions")
+        string.capitalizeSuffix(string.length + 14)
+        XCTAssertEqual(string, "EZ SWIFT EXTENSIONS")
     }
 
     func testIsOnlyEmptySpacesAndNewLineCharacters() {

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
@@ -32,6 +32,9 @@ class EZSwiftExtensionsTestsString: XCTestCase {
         XCTAssertEqual(string, "EZSwiftExtensions")
 
         string = "ezswiftExtensions"
+        string.uppercasePrefix(-7)
+        XCTAssertEqual(string, "ezswiftExtensions")
+        XCTAssertEqual(string.uppercasedPrefix(0), "ezswiftExtensions")
         XCTAssertEqual(string.uppercasedPrefix(5), "EZSWIftExtensions")
         string.uppercasePrefix(3)
         XCTAssertEqual(string, "EZSwiftExtensions")
@@ -42,6 +45,9 @@ class EZSwiftExtensionsTestsString: XCTestCase {
         XCTAssertEqual(string, "EZ SWIFT EXTENSIONS")
 
         string = "ezswiftExtensions"
+        string.uppercaseSuffix(0)
+        XCTAssertEqual(string, "ezswiftExtensions")
+        XCTAssertEqual(string.uppercasedSuffix(-3), "ezswiftExtensions")
         XCTAssertEqual(string.uppercasedSuffix(6), "ezswiftExteNSIONS")
         string.uppercaseSuffix(4)
         XCTAssertEqual(string, "ezswiftExtensIONS")

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
@@ -56,6 +56,15 @@ class EZSwiftExtensionsTestsString: XCTestCase {
         XCTAssertEqual(string, "ez swift extensions")
         string.uppercaseSuffix(string.length + 14)
         XCTAssertEqual(string, "EZ SWIFT EXTENSIONS")
+
+        string = "ezswiftExtensions"
+        XCTAssertEqual(string.uppercased(range: string.length+1..<string.length+15), "ezswiftExtensions")
+        string.uppercase(range: string.length+7..<string.length+99)
+        XCTAssertEqual(string, "ezswiftExtensions")
+        XCTAssertEqual(string.uppercased(range: -5..<5), "EZSWIftExtensions")
+        XCTAssertEqual(string.uppercased(range: 4..<10), "ezswIFTEXTensions")
+        string.uppercase(range: 8..<13)
+        XCTAssertEqual(string, "ezswiftEXTENSions")
     }
 
     func testIsOnlyEmptySpacesAndNewLineCharacters() {

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsString.swift
@@ -32,23 +32,23 @@ class EZSwiftExtensionsTestsString: XCTestCase {
         XCTAssertEqual(string, "EZSwiftExtensions")
 
         string = "ezswiftExtensions"
-        XCTAssertEqual(string.capitalizedPrefix(5), "EZSWIftExtensions")
-        string.capitalizePrefix(3)
+        XCTAssertEqual(string.uppercasedPrefix(5), "EZSWIftExtensions")
+        string.uppercasePrefix(3)
         XCTAssertEqual(string, "EZSwiftExtensions")
         string = "ez swift extensions"
-        XCTAssertEqual(string.capitalizedPrefix(string.length + 1), "EZ SWIFT EXTENSIONS")
+        XCTAssertEqual(string.uppercasedPrefix(string.length + 1), "EZ SWIFT EXTENSIONS")
         XCTAssertEqual(string, "ez swift extensions")
-        string.capitalizePrefix(string.length + 14)
+        string.uppercasePrefix(string.length + 14)
         XCTAssertEqual(string, "EZ SWIFT EXTENSIONS")
 
         string = "ezswiftExtensions"
-        XCTAssertEqual(string.capitalizedSuffix(6), "ezswiftExteNSIONS")
-        string.capitalizeSuffix(4)
+        XCTAssertEqual(string.uppercasedSuffix(6), "ezswiftExteNSIONS")
+        string.uppercaseSuffix(4)
         XCTAssertEqual(string, "ezswiftExtensIONS")
         string = "ez swift extensions"
-        XCTAssertEqual(string.capitalizedSuffix(string.length + 1), "EZ SWIFT EXTENSIONS")
+        XCTAssertEqual(string.uppercasedSuffix(string.length + 1), "EZ SWIFT EXTENSIONS")
         XCTAssertEqual(string, "ez swift extensions")
-        string.capitalizeSuffix(string.length + 14)
+        string.uppercaseSuffix(string.length + 14)
         XCTAssertEqual(string, "EZ SWIFT EXTENSIONS")
     }
 

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -74,14 +74,14 @@ extension String {
         return result
     }
     
-    /// EZSE: Capitalizes first 'count' characters of String
+    /// EZSE: Uppercases first 'count' characters of String
     public mutating func uppercasePrefix(count: Int) {
         guard characters.count > 0 && count > 0 else { return }
         self.replaceRange(startIndex..<startIndex.advancedBy(min(count, length)),
                           with: String(self[startIndex..<startIndex.advancedBy(min(count, length))]).uppercaseString)
     }
     
-    /// EZSE: Capitalizes first 'count' characters of String, returns a new string
+    /// EZSE: Uppercases first 'count' characters of String, returns a new string
     public func uppercasedPrefix(count: Int) -> String {
         guard characters.count > 0 && count > 0 else { return self }
         var result = self
@@ -90,14 +90,14 @@ extension String {
         return result
     }
     
-    /// EZSE: Capitalizes last 'count' characters of String
+    /// EZSE: Uppercases last 'count' characters of String
     public mutating func uppercaseSuffix(count: Int) {
         guard characters.count > 0 && count > 0 else { return }
         self.replaceRange(endIndex.advancedBy(-min(count, length))..<endIndex,
                           with: String(self[endIndex.advancedBy(-min(count, length))..<endIndex]).uppercaseString)
     }
     
-    /// EZSE: Capitalizes first 'count' characters of String, returns a new string
+    /// EZSE: Uppercases last 'count' characters of String, returns a new string
     public func uppercasedSuffix(count: Int) -> String {
         guard characters.count > 0 && count > 0 else { return self }
         var result = self
@@ -105,6 +105,25 @@ extension String {
                             with: String(self[endIndex.advancedBy(-min(count, length))..<endIndex]).uppercaseString)
         return result
     }
+    
+    /// EZSE: Uppercases string in range 'range' (from range.startIndex to range.endIndex)
+    public mutating func uppercase(range range: Range<Int>) {
+        let from = max(range.startIndex, 0), to = min(range.endIndex, length)
+        guard characters.count > 0 && (0..<length).contains(from) else { return }
+        self.replaceRange(startIndex.advancedBy(from)..<startIndex.advancedBy(to),
+                          with: String(self[startIndex.advancedBy(from)..<startIndex.advancedBy(to)]).uppercaseString)
+    }
+    
+    /// EZSE: Uppercases string in range 'range' (from range.startIndex to range.endIndex), returns new string
+    public func uppercased(range range: Range<Int>) -> String {
+        let from = max(range.startIndex, 0), to = min(range.endIndex, length)
+        guard characters.count > 0 && (0..<length).contains(from) else { return self }
+        var result = self
+        result.replaceRange(startIndex.advancedBy(from)..<startIndex.advancedBy(to),
+                          with: String(self[startIndex.advancedBy(from)..<startIndex.advancedBy(to)]).uppercaseString)
+        return result
+    }
+    
 
     /// EZSE: Counts whitespace & new lines
     public func isOnlyEmptySpacesAndNewLineCharacters() -> Bool {

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -75,14 +75,14 @@ extension String {
     }
     
     /// EZSE: Capitalizes first 'count' characters of String
-    public mutating func capitalizePrefix(count: Int) {
+    public mutating func uppercasePrefix(count: Int) {
         guard characters.count > 0 && count > 0 else { return }
         self.replaceRange(startIndex..<startIndex.advancedBy(min(count, length)),
                           with: String(self[startIndex..<startIndex.advancedBy(min(count, length))]).uppercaseString)
     }
     
     /// EZSE: Capitalizes first 'count' characters of String, returns a new string
-    public func capitalizedPrefix(count: Int) -> String {
+    public func uppercasedPrefix(count: Int) -> String {
         guard characters.count > 0 && count > 0 else { return self }
         var result = self
         result.replaceRange(startIndex..<startIndex.advancedBy(min(count, length)),
@@ -91,14 +91,14 @@ extension String {
     }
     
     /// EZSE: Capitalizes last 'count' characters of String
-    public mutating func capitalizeSuffix(count: Int) {
+    public mutating func uppercaseSuffix(count: Int) {
         guard characters.count > 0 && count > 0 else { return }
         self.replaceRange(endIndex.advancedBy(-min(count, length))..<endIndex,
                           with: String(self[endIndex.advancedBy(-min(count, length))..<endIndex]).uppercaseString)
     }
     
     /// EZSE: Capitalizes first 'count' characters of String, returns a new string
-    public func capitalizedSuffix(count: Int) -> String {
+    public func uppercasedSuffix(count: Int) -> String {
         guard characters.count > 0 && count > 0 else { return self }
         var result = self
         result.replaceRange(endIndex.advancedBy(-min(count, length))..<endIndex,

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -73,6 +73,38 @@ extension String {
         result.replaceRange(startIndex...startIndex, with: String(self[startIndex]).capitalizedString)
         return result
     }
+    
+    /// EZSE: Capitalizes first 'count' characters of String
+    public mutating func capitalizePrefix(count: Int) {
+        guard characters.count > 0 && count > 0 else { return }
+        self.replaceRange(startIndex..<startIndex.advancedBy(min(count, length)),
+                          with: String(self[startIndex..<startIndex.advancedBy(min(count, length))]).uppercaseString)
+    }
+    
+    /// EZSE: Capitalizes first 'count' characters of String, returns a new string
+    public func capitalizedPrefix(count: Int) -> String {
+        guard characters.count > 0 && count > 0 else { return self }
+        var result = self
+        result.replaceRange(startIndex..<startIndex.advancedBy(min(count, length)),
+                            with: String(self[startIndex..<startIndex.advancedBy(min(count, length))]).uppercaseString)
+        return result
+    }
+    
+    /// EZSE: Capitalizes last 'count' characters of String
+    public mutating func capitalizeSuffix(count: Int) {
+        guard characters.count > 0 && count > 0 else { return }
+        self.replaceRange(endIndex.advancedBy(-min(count, length))..<endIndex,
+                          with: String(self[endIndex.advancedBy(-min(count, length))..<endIndex]).uppercaseString)
+    }
+    
+    /// EZSE: Capitalizes first 'count' characters of String, returns a new string
+    public func capitalizedSuffix(count: Int) -> String {
+        guard characters.count > 0 && count > 0 else { return self }
+        var result = self
+        result.replaceRange(endIndex.advancedBy(-min(count, length))..<endIndex,
+                            with: String(self[endIndex.advancedBy(-min(count, length))..<endIndex]).uppercaseString)
+        return result
+    }
 
     /// EZSE: Counts whitespace & new lines
     public func isOnlyEmptySpacesAndNewLineCharacters() -> Bool {

--- a/Sources/UITextFieldExtensions.swift
+++ b/Sources/UITextFieldExtensions.swift
@@ -14,7 +14,7 @@ extension UITextField {
     public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat) {
         self.init(x: x, y: y, w: w, h: h, fontSize: 17)
     }
-    
+
     /// EZSwiftExtensions: Automatically sets these values: backgroundColor = clearColor, textColor = ThemeNicknameColor, clipsToBounds = true,
     /// textAlignment = Left, userInteractionEnabled = true, editable = false, scrollEnabled = false, font = ThemeFontName
     public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat, fontSize: CGFloat) {
@@ -25,21 +25,21 @@ extension UITextField {
         textAlignment = NSTextAlignment.Left
         userInteractionEnabled = true
     }
-    
+
     /// EZSE: Add left padding to the text in textfield
     func addLeftTextPadding(blankSize: CGFloat) {
         let leftView = UIView()
-        leftView.frame = CGRectMake(0, 0, blankSize, self.frame.height)
+        leftView.frame = CGRect(x: 0, y: 0, width: blankSize, height: frame.height)
         self.leftView = leftView
         self.leftViewMode = UITextFieldViewMode.Always
     }
-    
+
     /// EZSE: Add a image icon on the left side of the textfield
     func addLeftIcon(image: UIImage?, frame: CGRect, imageSize: CGSize) {
         let leftView = UIView()
         leftView.frame = frame
         let imgView = UIImageView()
-        imgView.frame = CGRectMake(frame.width - 8 - imageSize.width, (frame.height - imageSize.height) / 2, imageSize.width, imageSize.height)
+        imgView.frame = CGRect(x: frame.width - 8 - imageSize.width, y: (frame.height - imageSize.height) / 2, w: imageSize.width, h: imageSize.height)
         imgView.image = image
         leftView.addSubview(imgView)
         self.leftView = leftView


### PR DESCRIPTION
Wrapped this ugly thing:

```
str.replaceRange(startIndex..<startIndex.advancedBy(min(count, length)),
                          with: String(self[startIndex..<startIndex.advancedBy(min(count, length))]).uppercaseString)
```

into this:

`str.capitalizeFirst(count)`

Also this PR includes fixes for SwiftLint (legacy constructors)