### PR TITLE
add decompose function in Array

### DIFF
--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
@@ -158,4 +158,19 @@ class EZSwiftExtensionsTestsArray: XCTestCase {
         }
         XCTAssertEqual(numberArray, [])
     }
+
+    func testDecompose() {
+        let a: [Int] = []
+        let b: [Int] = [1]
+        let c: [Int] = [1, 2]
+        XCTAssertNil(a.decompose())
+        XCTAssertTrue(b.decompose()!.head == 1 && b.decompose()!.tail == [])
+        XCTAssertTrue(c.decompose()!.head == 1 && c.decompose()!.tail == [2])
+
+        let copyArray = numberArray
+        let head = copyArray.first!
+        let tail = copyArray.dropFirst()
+        XCTAssertTrue(numberArray.decompose()!.head == head)
+        XCTAssertTrue(numberArray.decompose()!.tail == tail)
+    }
 }

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -105,6 +105,12 @@ extension Array {
             if i != i+j { swap(&self[i], &self[i+j]) }
         }
     }
+    
+    /// EZSE: Decompose an array to a tuple with first element and the rest; useful in Functional Programming
+    public func decompose() -> (head: Generator.Element, tail: SubSequence)? {
+        return (count > 0) ? (self[0], self[1..<count]) : nil
+    }
+
 }
 
 extension Array where Element: Equatable {

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -105,7 +105,7 @@ extension Array {
             if i != i+j { swap(&self[i], &self[i+j]) }
         }
     }
-    
+
     /// EZSE: Decompose an array to a tuple with first element and the rest; useful in Functional Programming
     public func decompose() -> (head: Generator.Element, tail: SubSequence)? {
         return (count > 0) ? (self[0], self[1..<count]) : nil


### PR DESCRIPTION
Function that decompose an array to a tuple with first element and the rest; useful in Functional Programming.
For example, doing a quicksort in a few lines:
```swift
extension Array where Element: Comparable {
    func quicksort() -> Array<Element> {
        if let (head, tail) = self.decompose() {
            return tail.filter { $0 <= head }.quicksort() + [head] + tail.filter { $0 > head }.quicksort()
        } else { return [] }
    }
}
```