### PR TITLE
deprecate each in Array Extension

### DIFF
--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
@@ -97,7 +97,7 @@ class EZSwiftExtensionsTestsArray: XCTestCase {
 
     func testEach() {
         var sameArray: [Int] = []
-        numberArray.each { sameArray.append($0) }
+        numberArray.forEach { sameArray.append($0) }
         XCTAssertEqual(numberArray, sameArray)
 
         var indexArray: [Int] = []

--- a/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
+++ b/EZSwiftExtensionsTests/EZSwiftExtensionsTestsArray.swift
@@ -101,7 +101,7 @@ class EZSwiftExtensionsTestsArray: XCTestCase {
         XCTAssertEqual(numberArray, sameArray)
 
         var indexArray: [Int] = []
-        numberArray.each { indexArray.append($0.0) }
+        numberArray.forEach { indexArray.append($0.0) }
         XCTAssertEqual(indexArray, [Int](0..<numberArray.count))
     }
 

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -74,7 +74,15 @@ extension Array {
     }
 
     /// EZSE: Iterates on each element of the array with its index.
+    @available(*, deprecated=1.6, renamed="forEach")
     public func each(call: (Int, Element) -> ()) {
+        for (index, item) in self.enumerate() {
+            call(index, item)
+        }
+    }
+
+    /// EZSE: Iterates on each element of the array with its index.
+    public func forEach(call: (Int, Element) -> ()) {
         for (index, item) in self.enumerate() {
             call(index, item)
         }

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -66,6 +66,7 @@ extension Array {
     }
 
     /// EZSE: Iterates on each element of the array.
+    @available(*, deprecated=1.6)
     public func each(call: (Element) -> ()) {
         for item in self {
             call(item)
@@ -83,7 +84,7 @@ extension Array {
     /// through the mapFunction and discarding nil return values.
     public func mapFilter<V>(mapFunction map: (Element) -> (V)?) -> [V] {
         var mapped = [V]()
-        each { (value: Element) -> Void in
+        forEach { (value: Element) -> Void in
             if let mappedValue = map(value) {
                 mapped.append(mappedValue)
             }
@@ -162,7 +163,7 @@ extension Array where Element: Equatable {
 
             //  find common elements and save them in first set
             //  to intersect in the next loop
-            value.each { (item: Element) -> Void in
+            value.forEach { (item: Element) -> Void in
                 if result.contains(item) {
                     intersection.append(item)
                 }

--- a/Sources/UIViewExtensions.swift
+++ b/Sources/UIViewExtensions.swift
@@ -28,14 +28,14 @@ extension UIView {
 
 // MARK: Frame Extensions
 extension UIView {
-    
+
     /// EZSwiftExtensions, add multiple subviews
     public func addSubviews(views: [UIView]) {
         views.forEach { eachView in
             self.addSubview(eachView)
         }
     }
-    
+
     //TODO: Add pics to readme
     /// EZSwiftExtensions, resizes this view so it fits the largest subview
     public func resizeToFitSubviews() {


### PR DESCRIPTION
Deprecate `each` function in Array extension, because there's native `forEach` function that serves exactly the same as `each`. Feel no need for duplicating same method.