### PR TITLE
New algorithm for UIImage Extension methods

### DIFF
--- a/EZSwiftExtensions.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensions.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		79AB4F331D03394F009183EC /* UIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79AB4F2C1D03394F009183EC /* UIApplicationExtensions.swift */; };
 		79AB4F341D03394F009183EC /* UIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79AB4F2C1D03394F009183EC /* UIApplicationExtensions.swift */; };
 		8889A85B1D20E8D500635002 /* UITextFieldExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8889A85A1D20E8D500635002 /* UITextFieldExtensions.swift */; };
+		88A1232C1D68FA1B00717973 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A1232B1D68FA1B00717973 /* ImageLoader.swift */; };
 		988DA77E1D115FA900F8468F /* UIStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988DA77D1D115FA900F8468F /* UIStoryboardExtensions.swift */; };
 		988DA77F1D115FB900F8468F /* UIStoryboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988DA77D1D115FA900F8468F /* UIStoryboardExtensions.swift */; };
 		AFBEC7861CB347D50023408E /* NSBundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBEC7851CB347D50023408E /* NSBundleExtensions.swift */; };
@@ -156,6 +157,7 @@
 		79AB4F2B1D03394F009183EC /* NSDictionaryExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDictionaryExtensions.swift; sourceTree = "<group>"; };
 		79AB4F2C1D03394F009183EC /* UIApplicationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIApplicationExtensions.swift; sourceTree = "<group>"; };
 		8889A85A1D20E8D500635002 /* UITextFieldExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextFieldExtensions.swift; sourceTree = "<group>"; };
+		88A1232B1D68FA1B00717973 /* ImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		988DA77D1D115FA900F8468F /* UIStoryboardExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtensions.swift; sourceTree = "<group>"; };
 		AFBEC7851CB347D50023408E /* NSBundleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSBundleExtensions.swift; sourceTree = "<group>"; };
 		B5DC86A91C0ED06700972D0A /* EZSwiftExtensions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EZSwiftExtensions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -337,6 +339,7 @@
 				B5DC871A1C0ED34300972D0A /* UIViewControllerExtensions.swift */,
 				B5DC871B1C0ED34300972D0A /* UIViewExtensions.swift */,
 				E17878231C86861900BC05AA /* UIWindowExtensions.swift */,
+				88A1232B1D68FA1B00717973 /* ImageLoader.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -578,6 +581,7 @@
 				E1F21CB51CB55CDA004A01A4 /* EZSwiftFunctions.swift in Sources */,
 				E178781C1C8678AA00BC05AA /* UISliderExtensions.swift in Sources */,
 				B5DC87321C0ED34300972D0A /* UIFontExtensions.swift in Sources */,
+				88A1232C1D68FA1B00717973 /* ImageLoader.swift in Sources */,
 				B5DC87331C0ED34300972D0A /* UIImageExtensions.swift in Sources */,
 				B5DC87341C0ED34300972D0A /* UIImageViewExtensions.swift in Sources */,
 				B5DC87351C0ED34300972D0A /* UILabelExtensions.swift in Sources */,

--- a/Sources/ImageLoader.swift
+++ b/Sources/ImageLoader.swift
@@ -1,0 +1,48 @@
+//
+//  ImageLoader.swift
+//  EZSwiftExtensions
+//
+//  Created by Wang Yu on 8/20/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import UIKit
+
+public class ImageLoader {
+    
+    var cache = NSCache()
+    
+    static let sharedInstance: ImageLoader = ImageLoader()
+    
+    public func imageForUrl(urlString: String, completionHandler:(image: UIImage?, url: String) -> ()) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), {()in
+            let data: NSData? = self.cache.objectForKey(urlString) as? NSData
+            
+            if let goodData = data {
+                let image = UIImage(data: goodData)
+                dispatch_async(dispatch_get_main_queue(), {() in
+                    completionHandler(image: image, url: urlString)
+                })
+                return
+            }
+            
+            let downloadTask: NSURLSessionDataTask = NSURLSession.sharedSession().dataTaskWithURL(NSURL(string: urlString)!, completionHandler: { (data, response, error) -> Void in
+                if (error != nil) {
+                    completionHandler(image: nil, url: urlString)
+                    return
+                }
+                
+                if data != nil {
+                    let image = UIImage(data: data!)
+                    self.cache.setObject(data!, forKey: urlString)
+                    dispatch_async(dispatch_get_main_queue(), {() in
+                        completionHandler(image: image, url: urlString)
+                    })
+                    return
+                }
+            })
+            downloadTask.resume()
+        })
+        
+    }
+}

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -357,6 +357,11 @@ extension String {
         }
         return nil
     }
+    
+    /// EZSE: Converts String to NSURL
+    public func toURL() -> NSURL? {
+        return NSURL(string: self)
+    }
 
     ///EZSE: Returns the first index of the occurency of the character in String
     public func getIndexOf(char: Character) -> Int? {

--- a/Sources/UIImageViewExtensions.swift
+++ b/Sources/UIImageViewExtensions.swift
@@ -75,30 +75,33 @@ extension UIImageView {
 
     /// EZSwiftExtensions
     public func imageWithUrl(url url: String) {
-        ez.requestImage(url, success: { (image) -> Void in
-            if let img = image {
-                self.image = img
-            }
-        })
+        imageWithUrlHelper(url.toURL(), placeholderImage: nil)
     }
 
     /// EZSwiftExtensions
     public func imageWithUrl(url url: String, placeholder: UIImage) {
-        self.image = placeholder
-        ez.requestImage(url, success: { (image) -> Void in
-            if let img = image {
-                self.image = img
-            }
-        })
+        imageWithUrlHelper(url.toURL(), placeholderImage: placeholder)
     }
 
     /// EZSwiftExtensions
     public func imageWithUrl(url url: String, placeholderNamed: String) {
-        self.image = UIImage(named: placeholderNamed)
-        ez.requestImage(url, success: { (image) -> Void in
-            if let img = image {
-                self.image = img
+        imageWithUrlHelper(url.toURL(), placeholderImage: UIImage(named: placeholderNamed))
+    }
+    
+    private func imageWithUrlHelper(url: NSURL?, placeholderImage: UIImage?) {
+        if let placeholder = placeholderImage {
+            self.image = placeholder
+        }
+        if let urlString = url?.absoluteString {
+            ImageLoader.sharedInstance.imageForUrl(urlString) { [weak self] image, url in
+                if let strongSelf = self {
+                    dispatch_async(dispatch_get_main_queue()) {
+                        if urlString == url {
+                            strongSelf.image = image ?? placeholderImage
+                        }
+                    }
+                }
             }
-        })
+        }
     }
 }

--- a/Sources/UIImageViewExtensions.swift
+++ b/Sources/UIImageViewExtensions.swift
@@ -65,8 +65,12 @@ extension UIImageView {
 
     /// EZSwiftExtensions
     public func roundSquareImage() {
-        self.clipsToBounds = true
-        self.layer.cornerRadius = self.frame.size.width / 2
+        let image = self.image
+        UIGraphicsBeginImageContextWithOptions(self.bounds.size, false, UIScreen.mainScreen().scale)
+        UIBezierPath(roundedRect: self.bounds, cornerRadius: self.bounds.width).addClip()
+        image?.drawInRect(self.bounds)
+        self.image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
     }
 
     /// EZSwiftExtensions


### PR DESCRIPTION
Using `UIBezierPath` to `addClip` UIImage to have roundedCorner is better than simple setting corner radius in two ways:
1. Avoiding side effects of setting additional `clipToBounds`
2. Avoiding offscreen rendering; useful when displaying a bunch rounded images

New class explicit for image downloading; a lot efficient and thread-safe than simple url request.
