### PR TITLE
Adds the global function `appBundleId`

### DIFF
--- a/Sources/EZSwiftFunctions.swift
+++ b/Sources/EZSwiftFunctions.swift
@@ -43,6 +43,11 @@ public struct ez {
         return nil
     }
 
+    /// EZSE: Returns the app's bundle identifier
+    public static var appBundleId: String? {
+        return NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleIdentifier") as? String
+    }
+
     /// EZSE: Return device version ""
     public static var deviceVersion: String {
         var size: Int = 0


### PR DESCRIPTION
This function returns the app's bundle id from the Info.plist, i.e. the key `CFBundleIdentifier`