### PR TITLE
Error type tests

### DIFF
--- a/EZSwiftExtensionsTests/ErrorTypeTests.swift
+++ b/EZSwiftExtensionsTests/ErrorTypeTests.swift
@@ -8,20 +8,20 @@
 
 import XCTest
 
-enum CustomErrorEnum: ErrorType {
-    case CustomError, AnotherError
+enum ErrorEnum: String, ErrorType {
+    case CustomError
+    case AnotherError = "String Another Error"
 }
 
-struct CustomErrorStruct: ErrorType { }
+struct ErrorStruct: ErrorType { }
+
+class ErrorClass: ErrorType { }
 
 class CustomErrorClass: ErrorType {
-
     let description: String
-
     init(description: String) {
         self.description = description
     }
-
     var toString: String {
         return description
     }
@@ -29,23 +29,26 @@ class CustomErrorClass: ErrorType {
 
 class ErrorTypeTests: XCTestCase {
 
-    var enumError: CustomErrorEnum!
-    var structError: CustomErrorStruct!
-    var classError: CustomErrorClass!
+    var enumError: ErrorEnum!
+    var structError: ErrorStruct!
+    var classError: ErrorClass!
+    var customClassError: CustomErrorClass!
 
     override func setUp() {
         super.setUp()
         enumError = .CustomError
-        structError = CustomErrorStruct()
-        classError = CustomErrorClass(description: "Custom Error To String")
+        structError = ErrorStruct()
+        classError = ErrorClass()
+        customClassError = CustomErrorClass(description: "Custom Error To String")
     }
 
     func testToString() {
         XCTAssertEqual(enumError.toString, "CustomError")
         enumError = .AnotherError
-        XCTAssertEqual(enumError.toString, "AnotherError")
-        XCTAssertEqual(structError.toString, "CustomErrorStruct")
-        XCTAssertEqual(classError.toString, "Custom Error To String")
+        XCTAssertEqual(enumError.toString, "String Another Error")
+        XCTAssertEqual(structError.toString, "ErrorStruct")
+        XCTAssertEqual(classError.toString, "ErrorClass")
+        XCTAssertEqual(customClassError.toString, "Custom Error To String")
     }
 
 }

--- a/EZSwiftExtensionsTests/ErrorTypeTests.swift
+++ b/EZSwiftExtensionsTests/ErrorTypeTests.swift
@@ -8,9 +8,44 @@
 
 import XCTest
 
-class ErrorTypeTests: XCTestCase {
-
-    
-
+enum CustomErrorEnum: ErrorType {
+    case CustomError, AnotherError
 }
 
+struct CustomErrorStruct: ErrorType { }
+
+class CustomErrorClass: ErrorType {
+
+    let description: String
+
+    init(description: String) {
+        self.description = description
+    }
+
+    var toString: String {
+        return description
+    }
+}
+
+class ErrorTypeTests: XCTestCase {
+
+    var enumError: CustomErrorEnum!
+    var structError: CustomErrorStruct!
+    var classError: CustomErrorClass!
+
+    override func setUp() {
+        super.setUp()
+        enumError = .CustomError
+        structError = CustomErrorStruct()
+        classError = CustomErrorClass(description: "Custom Error To String")
+    }
+
+    func testToString() {
+        XCTAssertEqual(enumError.toString, "CustomError")
+        enumError = .AnotherError
+        XCTAssertEqual(enumError.toString, "AnotherError")
+        XCTAssertEqual(structError.toString, "CustomErrorStruct")
+        XCTAssertEqual(classError.toString, "Custom Error To String")
+    }
+
+}


### PR DESCRIPTION
toString should not be a property, it should be func, or property like string.

Also, current behaviour is not as expected:
- [ ] enums return its case representations to strings, but `case CaseOne = "some case"` still returns `"CaseOne"`, don't know for this case, how it should be handled
- [ ] structs return `StructTypeName()` instead `StructTypeName`
- [ ] classes return `Module.ClassName` instead `ClassName`