### PR TITLE
Tests for DoubleExtensions

### DIFF
--- a/EZSwiftExtensionsTests/DoubleTests.swift
+++ b/EZSwiftExtensionsTests/DoubleTests.swift
@@ -13,7 +13,7 @@ class DoubleTests: XCTestCase {
 
     var double = 3.14
     var otherDouble = -147.9564
-    var anotherDouble = 231349.678450342834857392948575930204857593843483
+    var anotherDouble = 231349.678450342834857392948575
 
     override func setUp() {
         super.setUp()
@@ -58,19 +58,35 @@ extension DoubleTests {
         XCTAssertNotEqual(otherDouble, savedOtherDouble)
 
         anotherDouble.roundByPlaces(3)
-        XCTAssertEqual(anotherDouble, 231349.679)
-        XCTAssertEqual(anotherDouble.getRoundedByPlaces(-7), 231349.679)
+        XCTAssertEqual(anotherDouble, 231349.678)
+        XCTAssertEqual(anotherDouble.getRoundedByPlaces(-7), 231349.678)
         XCTAssertEqual(anotherDouble.getRoundedByPlaces(0), 231350)
     }
 
     func testCeiling() {
         XCTAssertEqual(double.getCeiledByPlaces(10), double)
         XCTAssertEqual(double.getCeiledByPlaces(1), 3.2)
+        double.ceilByPlaces(1)
+        XCTAssertEqual(double, 3.2)
+        
         XCTAssertEqual(otherDouble.getCeiledByPlaces(3), -147.956)
         XCTAssertEqual(otherDouble.getCeiledByPlaces(2), -147.95)
+        otherDouble.ceilByPlaces(3)
+        XCTAssertEqual(otherDouble, -147.956)
+        otherDouble.ceilByPlaces(2)
+        XCTAssertEqual(otherDouble, -147.95)
+        
         XCTAssertEqual(anotherDouble.getCeiledByPlaces(3), 231349.679)
-        XCTAssertEqual(anotherDouble.getCeiledByPlaces(-7), 231349.678450343)
+        XCTAssertEqual(anotherDouble.getCeiledByPlaces(-7), 231349.678450342834857392948575)
         XCTAssertEqual(anotherDouble.getCeiledByPlaces(0), 231350)
+        anotherDouble.ceilByPlaces(-7)
+        XCTAssertEqual(anotherDouble, 231349.678450342834857392948575)
+        anotherDouble.ceilByPlaces(3)
+        XCTAssertEqual(anotherDouble, 231349.679)
+        XCTAssertEqual(anotherDouble.getCeiledByPlaces(3), 231349.679)
+        anotherDouble.ceilByPlaces(0)
+        XCTAssertEqual(anotherDouble, 231350)
+
     }
 
 }

--- a/EZSwiftExtensionsTests/DoubleTests.swift
+++ b/EZSwiftExtensionsTests/DoubleTests.swift
@@ -7,10 +7,70 @@
 //
 
 import XCTest
+import EZSwiftExtensions
 
 class DoubleTests: XCTestCase {
 
-    
+    var double = 3.14
+    var otherDouble = -147.9564
+    var anotherDouble = 231349.678450342834857392948575930204857593843483
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
 
 }
 
+extension DoubleTests {
+
+    func testToString() {
+        XCTAssertEqual(double.toString, "3.14")
+        XCTAssertEqual(otherDouble.toString, "-147.9564")
+        XCTAssertEqual(anotherDouble.toString, "231349.678450343")
+    }
+
+    func testToInt() {
+        XCTAssertEqual(double.toInt, 3)
+        XCTAssertEqual(otherDouble.toInt, -147)
+        XCTAssertEqual(anotherDouble.toInt, 231349)
+        XCTAssertNotEqual(Double(double.toInt), double)
+        XCTAssertNotEqual(Double(otherDouble.toInt), otherDouble)
+        XCTAssertNotEqual(Double(anotherDouble.toInt), anotherDouble)
+    }
+}
+
+extension DoubleTests {
+
+    func testRounding() {
+        let savedDouble = double
+        double.roundByPlaces(10)
+        XCTAssertEqual(double, savedDouble)
+        XCTAssertEqual(double.getRoundedByPlaces(5), double)
+
+        let savedOtherDouble = otherDouble
+        otherDouble.roundByPlaces(3)
+        XCTAssertEqual(otherDouble, -147.956)
+        XCTAssertEqual(otherDouble.getRoundedByPlaces(2), -147.96)
+        XCTAssertNotEqual(otherDouble, savedOtherDouble)
+
+        anotherDouble.roundByPlaces(3)
+        XCTAssertEqual(anotherDouble, 231349.679)
+        XCTAssertEqual(anotherDouble.getRoundedByPlaces(-7), 231349.679)
+        XCTAssertEqual(anotherDouble.getRoundedByPlaces(0), 231350)
+    }
+
+    func testCeiling() {
+        XCTAssertEqual(double.getCeiledByPlaces(10), double)
+        XCTAssertEqual(double.getCeiledByPlaces(1), 3.2)
+        XCTAssertEqual(otherDouble.getCeiledByPlaces(3), -147.956)
+        XCTAssertEqual(otherDouble.getCeiledByPlaces(2), -147.95)
+        XCTAssertEqual(anotherDouble.getCeiledByPlaces(3), 231349.679)
+        XCTAssertEqual(anotherDouble.getCeiledByPlaces(-7), 231349.678450343)
+        XCTAssertEqual(anotherDouble.getCeiledByPlaces(0), 231350)
+    }
+
+}

--- a/Sources/DoubleExtensions.swift
+++ b/Sources/DoubleExtensions.swift
@@ -14,7 +14,9 @@ extension Double {
 
     /// EZSE: Converts Double to Int
     public var toInt: Int { return Int(self) }
+}
 
+extension Double {
     /// EZSE: Returns a Double rounded to decimal
     public func getRoundedByPlaces(places: Int) -> Double {
         return castToDecimalByPlacesHelper(places, function: round)
@@ -30,24 +32,14 @@ extension Double {
         return castToDecimalByPlacesHelper(places, function: ceil)
     }
 
-    private func castToDecimalByPlacesHelper(places: Int, function: Double -> Double) -> Double {
+    /// EZSE: Ceils current Double to number of places
+    public mutating func ceilByPlaces(places: Int) {
+        self = castToDecimalByPlacesHelper(places, function: ceil)
+    }
+
+    private func castToDecimalByPlacesHelper(places: Int, function: (Double) -> Double) -> Double {
+        guard places >= 0 else { return self }
         let divisor = pow(10.0, Double(places))
         return function(self * divisor) / divisor
-    }
-}
-
-extension String {
-    init(_ value: Float, precision: Int) {
-        let nFormatter = NSNumberFormatter()
-        nFormatter.numberStyle = .DecimalStyle
-        nFormatter.maximumFractionDigits = precision
-        self = nFormatter.stringFromNumber(value)!
-    }
-
-    init(_ value: Double, precision: Int) {
-        let nFormatter = NSNumberFormatter()
-        nFormatter.numberStyle = .DecimalStyle
-        nFormatter.maximumFractionDigits = precision
-        self = nFormatter.stringFromNumber(value)!
     }
 }

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -462,6 +462,22 @@ extension String {
 
 }
 
+extension String {
+    init(_ value: Float, precision: Int) {
+        let nFormatter = NSNumberFormatter()
+        nFormatter.numberStyle = .DecimalStyle
+        nFormatter.maximumFractionDigits = precision
+        self = nFormatter.stringFromNumber(value)!
+    }
+    
+    init(_ value: Double, precision: Int) {
+        let nFormatter = NSNumberFormatter()
+        nFormatter.numberStyle = .DecimalStyle
+        nFormatter.maximumFractionDigits = precision
+        self = nFormatter.stringFromNumber(value)!
+    }
+}
+
 /// EZSE: Pattern matching of strings via defined functions
 public func ~=<T> (pattern: (T -> Bool), value: T) -> Bool {
     return pattern(value)


### PR DESCRIPTION
Okay, got some tests for Double... And a bit disappointed 🎱 .

Firstly, what's it doing in DoubleExtensions?

```
extension String {
    init(_ value: Float, precision: Int) { }
    init(_ value: Double, precision: Int) { }
}
```

Secondly, syntax is be... :) I don't know as for swift 2.x, but for swift 3.x we should have next:

```
func round(byPlaces places: Int) { }
func rounded(byPlaces places: Int) { }
func ceil(byPlaces places: Int) { }
func ceilled(byPlaces places: Int) { }
```

Or -ing instead of -ed. Also I add ceil in this pull request thus we do not have one yet.

So now for tests:

- [x] If I passing wrong value to func it should react appropriative. So error or no changing of value should occur.
- [x] What the rounding of 231349.67845 to 3 digits? Is it human like or computer just sees 4 after 3-rd digit and not incrementing 8?
- [x] Add ceilByPlaces and tests for it