### PR TITLE
FloatingPointExtensions + tests

### DIFF
--- a/EZSwiftExtensions.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensions.xcodeproj/project.pbxproj
@@ -199,6 +199,10 @@
 		E17878241C86861900BC05AA /* UIWindowExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17878231C86861900BC05AA /* UIWindowExtensions.swift */; };
 		E1D7CDD01CF8FFC7008E4C07 /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D7CDCF1CF8FFC7008E4C07 /* UIBarButtonItemExtensions.swift */; };
 		E1F21CB51CB55CDA004A01A4 /* EZSwiftFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F21CB41CB55CDA004A01A4 /* EZSwiftFunctions.swift */; };
+		FADFAA5C1D9D787D00CF9F7A /* FloatingPointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFAA5B1D9D787D00CF9F7A /* FloatingPointTests.swift */; };
+		FADFAA5D1D9D787D00CF9F7A /* FloatingPointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFAA5B1D9D787D00CF9F7A /* FloatingPointTests.swift */; };
+		FADFAA631D9D8C2F00CF9F7A /* FloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFAA621D9D8C2F00CF9F7A /* FloatingPointExtensions.swift */; };
+		FADFAA641D9D8C3E00CF9F7A /* FloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFAA621D9D8C2F00CF9F7A /* FloatingPointExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -319,6 +323,8 @@
 		E17878231C86861900BC05AA /* UIWindowExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIWindowExtensions.swift; sourceTree = "<group>"; };
 		E1D7CDCF1CF8FFC7008E4C07 /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
 		E1F21CB41CB55CDA004A01A4 /* EZSwiftFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EZSwiftFunctions.swift; sourceTree = "<group>"; };
+		FADFAA5B1D9D787D00CF9F7A /* FloatingPointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPointTests.swift; sourceTree = "<group>"; };
+		FADFAA621D9D8C2F00CF9F7A /* FloatingPointExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPointExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -402,6 +408,7 @@
 				E10A79661D6F65AF00735549 /* CharacterTests.swift */,
 				7605D3061C81FBB80046FAC3 /* DictionaryTests.swift */,
 				E10A79671D6F65AF00735549 /* DoubleTests.swift */,
+				FADFAA5B1D9D787D00CF9F7A /* FloatingPointTests.swift */,
 				E10A79331D6F3D0B00735549 /* EZSwiftFunctionsTests.swift */,
 				E10A79681D6F65AF00735549 /* ErrorTypeTests.swift */,
 				7605D3071C81FBB80046FAC3 /* IntTests.swift */,
@@ -459,6 +466,7 @@
 				31F868DA1C2B6E5E00542250 /* DoubleExtensions.swift */,
 				E15484E11CA2BCF0003B030E /* ErrorTypeExtensions.swift */,
 				E1F21CB41CB55CDA004A01A4 /* EZSwiftFunctions.swift */,
+				FADFAA621D9D8C2F00CF9F7A /* FloatingPointExtensions.swift */,
 				B5DC870C1C0ED34300972D0A /* IntExtensions.swift */,
 				E178780F1C8651EB00BC05AA /* NSAttributedStringExtensions.swift */,
 				AFBEC7851CB347D50023408E /* NSBundleExtensions.swift */,
@@ -696,6 +704,7 @@
 			files = (
 				E15484E21CA2BCF0003B030E /* ErrorTypeExtensions.swift in Sources */,
 				31F868DB1C2B6E5E00542250 /* DoubleExtensions.swift in Sources */,
+				FADFAA631D9D8C2F00CF9F7A /* FloatingPointExtensions.swift in Sources */,
 				B5DC871C1C0ED34300972D0A /* ArrayExtensions.swift in Sources */,
 				E10A79461D6F506400735549 /* UIStoryboardExtensions.swift in Sources */,
 				E17878241C86861900BC05AA /* UIWindowExtensions.swift in Sources */,
@@ -763,6 +772,7 @@
 				E10A79631D6F62DF00735549 /* BlockWebViewTests.swift in Sources */,
 				E10A795F1D6F62DF00735549 /* BlockSwipeTests.swift in Sources */,
 				E10A79871D6F65AF00735549 /* DoubleTests.swift in Sources */,
+				FADFAA5C1D9D787D00CF9F7A /* FloatingPointTests.swift in Sources */,
 				E10A79A31D6F65AF00735549 /* UIDeviceTests.swift in Sources */,
 				E10A79931D6F65AF00735549 /* NSTimerTests.swift in Sources */,
 				E10A79A51D6F65AF00735549 /* UIFontTests.swift in Sources */,
@@ -804,6 +814,7 @@
 			files = (
 				CD4D30B31CEEAFD900CB53BC /* ErrorTypeExtensions.swift in Sources */,
 				CD4D30B41CEEAFD900CB53BC /* DoubleExtensions.swift in Sources */,
+				FADFAA641D9D8C3E00CF9F7A /* FloatingPointExtensions.swift in Sources */,
 				CD4D30B51CEEAFD900CB53BC /* ArrayExtensions.swift in Sources */,
 				E10A79471D6F506400735549 /* UIStoryboardExtensions.swift in Sources */,
 				CD4D30B61CEEAFD900CB53BC /* UIWindowExtensions.swift in Sources */,
@@ -871,6 +882,7 @@
 				E10A79641D6F62DF00735549 /* BlockWebViewTests.swift in Sources */,
 				E10A79601D6F62DF00735549 /* BlockSwipeTests.swift in Sources */,
 				E10A79881D6F65AF00735549 /* DoubleTests.swift in Sources */,
+				FADFAA5D1D9D787D00CF9F7A /* FloatingPointTests.swift in Sources */,
 				E10A79A41D6F65AF00735549 /* UIDeviceTests.swift in Sources */,
 				E10A79941D6F65AF00735549 /* NSTimerTests.swift in Sources */,
 				E10A79A61D6F65AF00735549 /* UIFontTests.swift in Sources */,

--- a/EZSwiftExtensionsExample.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensionsExample.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		E1839E391BF79974002212C6 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1839E1D1BF79974002212C6 /* UIViewExtensions.swift */; };
 		E1CB3C1C1C25FFA000DF77CD /* DoubleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CB3C1B1C25FFA000DF77CD /* DoubleExtensions.swift */; };
 		E1D7CDCE1CF8FFB3008E4C07 /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D7CDCD1CF8FFB3008E4C07 /* UIBarButtonItemExtensions.swift */; };
+		FADFAA611D9D8BFE00CF9F7A /* FloatingPointExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFAA601D9D8BFE00CF9F7A /* FloatingPointExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -114,6 +115,7 @@
 		E1839E1D1BF79974002212C6 /* UIViewExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIViewExtensions.swift; path = Sources/UIViewExtensions.swift; sourceTree = SOURCE_ROOT; };
 		E1CB3C1B1C25FFA000DF77CD /* DoubleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DoubleExtensions.swift; path = Sources/DoubleExtensions.swift; sourceTree = SOURCE_ROOT; };
 		E1D7CDCD1CF8FFB3008E4C07 /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIBarButtonItemExtensions.swift; path = Sources/UIBarButtonItemExtensions.swift; sourceTree = SOURCE_ROOT; };
+		FADFAA601D9D8BFE00CF9F7A /* FloatingPointExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FloatingPointExtensions.swift; path = ../Sources/FloatingPointExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +148,7 @@
 				E1CB3C1B1C25FFA000DF77CD /* DoubleExtensions.swift */,
 				E15484E31CA2BD00003B030E /* ErrorTypeExtensions.swift */,
 				E1839E0E1BF79974002212C6 /* EZSwiftFunctions.swift */,
+				FADFAA601D9D8BFE00CF9F7A /* FloatingPointExtensions.swift */,
 				E1839E0F1BF79974002212C6 /* IntExtensions.swift */,
 				E17878151C86525A00BC05AA /* NSAttributedStringExtensions.swift */,
 				E10A794A1D6F5C5300735549 /* NSBundleExtensions.swift */,
@@ -312,6 +315,7 @@
 				E1839E361BF79974002212C6 /* UILabelExtensions.swift in Sources */,
 				E1839E281BF79974002212C6 /* CGRectExtensions.swift in Sources */,
 				E1839E331BF79974002212C6 /* UIFontExtensions.swift in Sources */,
+				FADFAA611D9D8BFE00CF9F7A /* FloatingPointExtensions.swift in Sources */,
 				C85840ED1C43B05200595696 /* NSURLExtensions.swift in Sources */,
 				E1839E261BF79974002212C6 /* BoolExtensions.swift in Sources */,
 				E1839E2B1BF79974002212C6 /* IntExtensions.swift in Sources */,

--- a/EZSwiftExtensionsTests/DoubleTests.swift
+++ b/EZSwiftExtensionsTests/DoubleTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import EZSwiftExtensions
+@testable import EZSwiftExtensions
 
 class DoubleTests: XCTestCase {
 
@@ -41,52 +41,4 @@ extension DoubleTests {
         XCTAssertNotEqual(Double(otherDouble.toInt), otherDouble)
         XCTAssertNotEqual(Double(anotherDouble.toInt), anotherDouble)
     }
-}
-
-extension DoubleTests {
-
-    func testRounding() {
-        let savedDouble = double
-        double.roundByPlaces(10)
-        XCTAssertEqual(double, savedDouble)
-        XCTAssertEqual(double.getRoundedByPlaces(5), double)
-
-        let savedOtherDouble = otherDouble
-        otherDouble.roundByPlaces(3)
-        XCTAssertEqual(otherDouble, -147.956)
-        XCTAssertEqual(otherDouble.getRoundedByPlaces(2), -147.96)
-        XCTAssertNotEqual(otherDouble, savedOtherDouble)
-
-        anotherDouble.roundByPlaces(3)
-        XCTAssertEqual(anotherDouble, 231349.678)
-        XCTAssertEqual(anotherDouble.getRoundedByPlaces(-7), 231349.678)
-        XCTAssertEqual(anotherDouble.getRoundedByPlaces(0), 231350)
-    }
-
-    func testCeiling() {
-        XCTAssertEqual(double.getCeiledByPlaces(10), double)
-        XCTAssertEqual(double.getCeiledByPlaces(1), 3.2)
-        double.ceilByPlaces(1)
-        XCTAssertEqual(double, 3.2)
-        
-        XCTAssertEqual(otherDouble.getCeiledByPlaces(3), -147.956)
-        XCTAssertEqual(otherDouble.getCeiledByPlaces(2), -147.95)
-        otherDouble.ceilByPlaces(3)
-        XCTAssertEqual(otherDouble, -147.956)
-        otherDouble.ceilByPlaces(2)
-        XCTAssertEqual(otherDouble, -147.95)
-        
-        XCTAssertEqual(anotherDouble.getCeiledByPlaces(3), 231349.679)
-        XCTAssertEqual(anotherDouble.getCeiledByPlaces(-7), 231349.678450342834857392948575)
-        XCTAssertEqual(anotherDouble.getCeiledByPlaces(0), 231350)
-        anotherDouble.ceilByPlaces(-7)
-        XCTAssertEqual(anotherDouble, 231349.678450342834857392948575)
-        anotherDouble.ceilByPlaces(3)
-        XCTAssertEqual(anotherDouble, 231349.679)
-        XCTAssertEqual(anotherDouble.getCeiledByPlaces(3), 231349.679)
-        anotherDouble.ceilByPlaces(0)
-        XCTAssertEqual(anotherDouble, 231350)
-
-    }
-
 }

--- a/EZSwiftExtensionsTests/FloatingPointTests.swift
+++ b/EZSwiftExtensionsTests/FloatingPointTests.swift
@@ -1,0 +1,119 @@
+//
+//  FloatingPointTests.swift
+//  EZSwiftExtensions
+//
+//  Created by Olexii Pyvovarov on 9/29/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import XCTest
+@testable import EZSwiftExtensions
+
+class FloatingPointTests: XCTestCase {
+
+    var piFloat         = Float(3.14159_26535_89793_23846)      //ir: 3.14159274
+    var piDouble        = 3.14159_26535_89793_23846             //ir: 3.1415926535897931
+    var piFloat80       = Float80(3.14159_26535_89793_23846)    //ir: 3.141592653589793116
+    var negativeDouble  = -147.956455                           //ir: -147.95645500000001
+    var anotherFloat    = Float32(199.959019)                   //ir: 199.959015
+    var bigFloat        = Float80(0.9278766111959092165201989)  //ir: 0.927876611195909251073
+
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+}
+
+extension FloatingPointTests {
+
+    func testRounding() {
+        XCTAssertEqual(piFloat.rounded(toPlaces: 7), 3.1415927)
+        XCTAssertEqual(piDouble.rounded(toPlaces: 7), 3.1415927)
+        XCTAssertEqual(piFloat80.rounded(toPlaces: 7), 3.1415927)
+        piFloat.round(toPlaces: 3)
+        XCTAssertEqual(piFloat, 3.142)
+        piDouble.round(toPlaces: 2)
+        XCTAssertEqual(piDouble, 3.14)
+        piFloat80.round(toPlaces: 1)
+        XCTAssertEqual(piFloat80, 3.1)
+
+        XCTAssertEqual(negativeDouble.rounded(toPlaces: 2), -147.96)
+        negativeDouble.round(toPlaces: 3)
+        XCTAssertEqual(negativeDouble, -147.956)
+
+        XCTAssertEqual(anotherFloat.rounded(toPlaces: 0), 200)
+        anotherFloat.round(toPlaces: 5)
+        XCTAssertEqual(anotherFloat, 199.95902)
+        anotherFloat.round(toPlaces: 3)
+        XCTAssertEqual(anotherFloat, 199.959)
+        XCTAssertEqual(anotherFloat.rounded(toPlaces: 10), 199.959)
+        XCTAssertEqual(anotherFloat.rounded(toPlaces: -5), 199.959)
+        anotherFloat.round(toPlaces: -77)
+        XCTAssertEqual(anotherFloat, 199.959)
+        XCTAssertEqual(anotherFloat.rounded(toPlaces: 0), 200)
+        anotherFloat.round(toPlaces: 2)
+        XCTAssertEqual(anotherFloat, 199.96)
+
+        XCTAssertEqual(bigFloat.rounded(toPlaces: 99), bigFloat)
+        XCTAssertEqual(bigFloat.rounded(toPlaces: -99), bigFloat)
+        XCTAssertEqual(bigFloat.rounded(toPlaces: 0), 1)
+        XCTAssertEqual(bigFloat.rounded(toPlaces: 10), 0.9278766112)
+        bigFloat.round(toPlaces: 16)
+        XCTAssertEqual(bigFloat, 0.9278766111959093)
+        bigFloat.round(toPlaces: -1)
+        XCTAssertEqual(bigFloat, 0.9278766111959093)
+        bigFloat.round(toPlaces: 16)
+        XCTAssertEqual(bigFloat, 0.9278766111959093)
+        bigFloat.round(toPlaces: 3)
+        XCTAssertEqual(bigFloat, 0.928)
+    }
+
+    func testCeiling() {
+        XCTAssertEqual(piFloat.ceiled(toPlaces: 5), 3.1416)
+        XCTAssertEqual(piDouble.ceiled(toPlaces: 5), 3.1416)
+        XCTAssertEqual(piFloat80.ceiled(toPlaces: 5), 3.1416)
+        piFloat.ceil(toPlaces: 3)
+        XCTAssertEqual(piFloat, 3.142)
+        piDouble.ceil(toPlaces: 2)
+        XCTAssertEqual(piDouble, 3.15)
+        piFloat80.ceil(toPlaces: 1)
+        XCTAssertEqual(piFloat80, 3.2)
+
+        XCTAssertEqual(negativeDouble.ceiled(toPlaces: 2), -147.95)
+        negativeDouble.ceil(toPlaces: 3)
+        XCTAssertEqual(negativeDouble, -147.956)
+
+        XCTAssertEqual(anotherFloat.ceiled(toPlaces: 0), 200)
+        anotherFloat.ceil(toPlaces: 4)
+        XCTAssertEqual(anotherFloat, 199.9591)
+        anotherFloat.ceil(toPlaces: 3)
+        XCTAssertEqual(anotherFloat, 199.96)
+        XCTAssertEqual(anotherFloat.ceiled(toPlaces: 10), 199.96)
+        XCTAssertEqual(anotherFloat.ceiled(toPlaces: -5), 199.96)
+        anotherFloat.ceil(toPlaces: -77)
+        XCTAssertEqual(anotherFloat, 199.96)
+        XCTAssertEqual(anotherFloat.ceiled(toPlaces: 0), 200)
+        anotherFloat.ceil(toPlaces: 2)
+        XCTAssertEqual(anotherFloat, 199.96)
+        anotherFloat.ceil(toPlaces: 1)
+        XCTAssertEqual(anotherFloat, 200)
+
+        XCTAssertEqual(bigFloat.ceiled(toPlaces: 99), bigFloat)
+        XCTAssertEqual(bigFloat.ceiled(toPlaces: -99), bigFloat)
+        XCTAssertEqual(bigFloat.ceiled(toPlaces: 0), 1)
+        XCTAssertEqual(bigFloat.ceiled(toPlaces: 10), 0.9278766112)
+        bigFloat.ceil(toPlaces: 16)
+        XCTAssertEqual(bigFloat, 0.9278766111959093)
+        bigFloat.ceil(toPlaces: -1)
+        XCTAssertEqual(bigFloat, 0.9278766111959093)
+        bigFloat.ceil(toPlaces: 16)
+        XCTAssertEqual(bigFloat, 0.9278766111959093)
+        bigFloat.ceil(toPlaces: 3)
+        XCTAssertEqual(bigFloat, 0.928)
+    }
+
+}

--- a/EZSwiftExtensionsTests/UIColorTests.swift
+++ b/EZSwiftExtensionsTests/UIColorTests.swift
@@ -42,8 +42,8 @@ class UIColorTests: XCTestCase {
         var blue: CGFloat = 0
         XCTAssertTrue(color.getRed(&red, green: &green, blue: &blue, alpha: nil))
         
-		let gray = Double(0.299 * red + 0.587 * green + 0.114 * blue).getRoundedByPlaces(7)
-		let testGray = (100 / 255).getRoundedByPlaces(7)
+        let gray = Double(0.299 * red + 0.587 * green + 0.114 * blue).rounded(toPlaces: 7)
+        let testGray = (100.0 / 255).rounded(toPlaces: 7)
 		XCTAssertEqual(gray, testGray)
 	}
 

--- a/Sources/DoubleExtensions.swift
+++ b/Sources/DoubleExtensions.swift
@@ -16,30 +16,32 @@ extension Double {
     public var toInt: Int { return Int(self) }
 }
 
+//MARK: - Deprecated 1.8
+
 extension Double {
+
     /// EZSE: Returns a Double rounded to decimal
+    @available(*, deprecated: 1.8, renamed: "rounded(toPlaces:)")
     public func getRoundedByPlaces(_ places: Int) -> Double {
-        return castToDecimalByPlacesHelper(places, function: Darwin.round)
+        return rounded(toPlaces: places)
     }
 
     /// EZSE: Rounds the current Double rounded to decimal
+    @available(*, deprecated: 1.8, renamed: "round(toPlaces:)")
     public mutating func roundByPlaces(_ places: Int) {
-        self = castToDecimalByPlacesHelper(places, function: Darwin.round)
+        self.round(toPlaces: places)
     }
 
     /// EZSE: Returns a Double Ceil to decimal
+    @available(*, deprecated: 1.8, renamed: "ceiled(toPlaces:)")
     public func getCeiledByPlaces(_ places: Int) -> Double {
-        return castToDecimalByPlacesHelper(places, function: Darwin.ceil)
+        return ceiled(toPlaces: places)
     }
 
     /// EZSE: Ceils current Double to number of places
+    @available(*, deprecated: 1.8, renamed: "ceil(toPlaces:)")
     public mutating func ceilByPlaces(_ places: Int) {
-        self = castToDecimalByPlacesHelper(places, function: Darwin.ceil)
+        self.ceil(toPlaces: places)
     }
 
-    fileprivate func castToDecimalByPlacesHelper(_ places: Int, function: (Double) -> Double) -> Double {
-        guard places >= 0 else { return self }
-        let divisor = pow(10.0, Double(places))
-        return function(self * divisor) / divisor
-    }
 }

--- a/Sources/FloatingPointExtensions.swift
+++ b/Sources/FloatingPointExtensions.swift
@@ -25,6 +25,7 @@ extension FloatingPoint {
         }
     }
 
+    /// EZSE: Returns rounded FloatingPoint to specified number of places
     public func rounded(toPlaces places: Int) -> Self {
         guard places >= 0 else { return self }
         //Float80 max decimal places = 18
@@ -33,11 +34,12 @@ extension FloatingPoint {
         return (self * div).rounded() / div
     }
 
-
+    /// EZSE: Rounds current FloatingPoint to specified number of places
     public mutating func round(toPlaces places: Int) {
         self = rounded(toPlaces: places)
     }
 
+    /// EZSE: Returns ceiled FloatingPoint to specified number of places
     public func ceiled(toPlaces places: Int) -> Self {
         guard places >= 0 else { return self }
         //Float80 max decimal places = 18
@@ -46,6 +48,7 @@ extension FloatingPoint {
         return (self * div).rounded(.up) / div
     }
 
+    /// EZSE: Ceils current FloatingPoint to specified number of places
     public mutating func ceil(toPlaces places: Int) {
         self = ceiled(toPlaces: places)
     }

--- a/Sources/FloatingPointExtensions.swift
+++ b/Sources/FloatingPointExtensions.swift
@@ -10,28 +10,12 @@ import Foundation
 
 extension FloatingPoint {
 
-    private func divisor(forPlaces places: Int) -> Self {
-        switch places {
-        case 0: return Self(1)
-        case 1: return Self(10)
-        case 2: return Self(100)
-        case 3: return Self(1000)
-        case 4: return Self(10000)
-        case 5: return Self(100000)
-        case 6: return Self(1000000)
-        case 7: return Self(10000000)
-        case 8: return Self(100000000)
-        default: return Self(100000000).multiplied(by: divisor(forPlaces: places - 8))
-        }
-    }
-
     /// EZSE: Returns rounded FloatingPoint to specified number of places
     public func rounded(toPlaces places: Int) -> Self {
         guard places >= 0 else { return self }
-        //Float80 max decimal places = 18
-        guard places <= 24 else { return rounded(toPlaces: 24) }
-        let div = divisor(forPlaces: places)
-        return (self * div).rounded() / div
+        var divisor = Self(1)
+        for _ in 0..<places { divisor.multiply(by: Self(10)) }
+        return (self * divisor).rounded() / divisor
     }
 
     /// EZSE: Rounds current FloatingPoint to specified number of places
@@ -42,10 +26,9 @@ extension FloatingPoint {
     /// EZSE: Returns ceiled FloatingPoint to specified number of places
     public func ceiled(toPlaces places: Int) -> Self {
         guard places >= 0 else { return self }
-        //Float80 max decimal places = 18
-        guard places <= 24 else { return ceiled(toPlaces: 24) }
-        let div = divisor(forPlaces: places)
-        return (self * div).rounded(.up) / div
+        var divisor = Self(1)
+        for _ in 0..<places { divisor.multiply(by: Self(10)) }
+        return (self * divisor).rounded(.up) / divisor
     }
 
     /// EZSE: Ceils current FloatingPoint to specified number of places

--- a/Sources/FloatingPointExtensions.swift
+++ b/Sources/FloatingPointExtensions.swift
@@ -1,0 +1,53 @@
+//
+//  FloatingPointExtensions.swift
+//  EZSwiftExtensionsExample
+//
+//  Created by Olexii Pyvovarov on 9/29/16.
+//  Copyright © 2016 Goktug Yilmaz. All rights reserved.
+//
+
+import Foundation
+
+extension FloatingPoint {
+
+    private func divisor(forPlaces places: Int) -> Self {
+        switch places {
+        case 0: return Self(1)
+        case 1: return Self(10)
+        case 2: return Self(100)
+        case 3: return Self(1000)
+        case 4: return Self(10000)
+        case 5: return Self(100000)
+        case 6: return Self(1000000)
+        case 7: return Self(10000000)
+        case 8: return Self(100000000)
+        default: return Self(100000000).multiplied(by: divisor(forPlaces: places - 8))
+        }
+    }
+
+    public func rounded(toPlaces places: Int) -> Self {
+        guard places >= 0 else { return self }
+        //Float80 max decimal places = 18
+        guard places <= 24 else { return rounded(toPlaces: 24) }
+        let div = divisor(forPlaces: places)
+        return (self * div).rounded() / div
+    }
+
+
+    public mutating func round(toPlaces places: Int) {
+        self = rounded(toPlaces: places)
+    }
+
+    public func ceiled(toPlaces places: Int) -> Self {
+        guard places >= 0 else { return self }
+        //Float80 max decimal places = 18
+        guard places <= 24 else { return ceiled(toPlaces: 24) }
+        let div = divisor(forPlaces: places)
+        return (self * div).rounded(.up) / div
+    }
+
+    public mutating func ceil(toPlaces places: Int) {
+        self = ceiled(toPlaces: places)
+    }
+
+}

--- a/Sources/FloatingPointExtensions.swift
+++ b/Sources/FloatingPointExtensions.swift
@@ -13,8 +13,8 @@ extension FloatingPoint {
     /// EZSE: Returns rounded FloatingPoint to specified number of places
     public func rounded(toPlaces places: Int) -> Self {
         guard places >= 0 else { return self }
-        var divisor = Self(1)
-        for _ in 0..<places { divisor.multiply(by: Self(10)) }
+        var divisor: Self = 1
+        for _ in 0..<places { divisor.multiply(by: 10) }
         return (self * divisor).rounded() / divisor
     }
 
@@ -26,8 +26,8 @@ extension FloatingPoint {
     /// EZSE: Returns ceiled FloatingPoint to specified number of places
     public func ceiled(toPlaces places: Int) -> Self {
         guard places >= 0 else { return self }
-        var divisor = Self(1)
-        for _ in 0..<places { divisor.multiply(by: Self(10)) }
+        var divisor: Self = 1
+        for _ in 0..<places { divisor.multiply(by: 10) }
         return (self * divisor).rounded(.up) / divisor
     }
 


### PR DESCRIPTION
Swift 3.0 API design guidelines:

`getRoundedByPlaces(_:)` is now `rounded(toPlaces:)`
`getCeiledByPlaces(_:)` is now `ceiled(toPlaces:)`
`roundByPlaces(_:)` is now `round(toPlaces:)`
`ceilByPlaces(_:)` is now `ceil(toPlaces:)`

**Significant change** Methods above are now part of FloatingPoint protocol extension with default implementation.

**Motivation:** 

round(ed) and ceil(ed) are useful for all floating types. In 1.7 version we have Double implemented round(ed) and ceil(ed), but Float are still missing these methods.

Okay, we could just copy-paste methods to Float extension, but it is not good to ignore reusability.

Let's move to protocol representing floating types - FloatingPoint protocol. 