### PR TITLE
Forbid merge commits in pr

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,9 @@
+# Contributors should write up some reasoning about the PR, rather than just leave a title
 if github.pr_body.length < 5
   fail "Please provide a summary in the Pull Request description"
+end
+
+# Ensure a clean commits history
+if git.commits.any? { |c| c.message =~ /^Merge branch '#{github.branch_for_base}'/ }
+  fail('Please rebase to get rid of the merge commits in this PR')
 end


### PR DESCRIPTION
**Motivation** 
Branch hell... Mostly by me, by the way...

Commits such ```Merge branch 'master' of https://github.com/goktugyil/EZSwiftExtensions into doubleExtensions``` are saying nothing about what was done.

<img width="863" alt="screen shot 2016-10-06 at 15 51 28" src="https://cloud.githubusercontent.com/assets/8293191/19152901/d96ed19a-8bdc-11e6-9af0-af33fba34c15.png">

**Improvment**

Contributors should use rebase, so no merge commits are going to pull request. If it's not done, then danger will show error (however it could be still merged if necessary). 

P.S. I tested at my fork, and it works. Also this is taken from cocoapods DangerFile.