### PR TITLE
Added Danger Xcode Summary Plugin from #242

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -17,3 +17,6 @@ end
 if git.modified_files.grep(/^EZSwiftExtensionsTests\//).count > 1
 	fail("Please, modify only one extension per pull request.")
 end
+
+xcode_summary.report 'xcodebuild.json'
+

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 source "https://rubygems.org"
 
 gem "danger"
+gem 'danger-xcode_summary'


### PR DESCRIPTION
I mentioned in #248 about it.
[Danger Xcode Summary Plugin](https://github.com/diogot/danger-xcode_summary) - A Danger plugin that shows all build errors, warnings and unit tests results generated from xcodebuild.
