### PR TITLE
Fixed #230

### DIFF
--- a/Sources/UIViewControllerExtensions.swift
+++ b/Sources/UIViewControllerExtensions.swift
@@ -106,9 +106,14 @@ extension UIViewController {
     }
 
     //EZSE: Makes the UIViewController register tap events and hides keyboard when clicked somewhere in the ViewController.
-    public func hideKeyboardWhenTappedAround(handler: ((UITapGestureRecognizer) -> Void)? = nil) {
+    public func hideKeyboardWhenTappedAround() {
         let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
-        handler?(tap)
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    public func hideKeyboardWhenTappedAroundAndCancelsTouchesInView() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
         view.addGestureRecognizer(tap)
     }
 

--- a/Sources/UIViewControllerExtensions.swift
+++ b/Sources/UIViewControllerExtensions.swift
@@ -106,8 +106,9 @@ extension UIViewController {
     }
 
     //EZSE: Makes the UIViewController register tap events and hides keyboard when clicked somewhere in the ViewController.
-    public func hideKeyboardWhenTappedAround() {
+    public func hideKeyboardWhenTappedAround(handler: ((UITapGestureRecognizer) -> Void)? = nil) {
         let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        handler?(tap)
         view.addGestureRecognizer(tap)
     }
 

--- a/Sources/UIViewControllerExtensions.swift
+++ b/Sources/UIViewControllerExtensions.swift
@@ -111,7 +111,7 @@ extension UIViewController {
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }
-    
+
     public func hideKeyboardWhenTappedAroundAndCancelsTouchesInView() {
         let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
         view.addGestureRecognizer(tap)


### PR DESCRIPTION
Extend `hideKeyboardWhenTappedAround` in order to  fix #230

e.g.
```
class ViewController: UIViewController {
    let tableView = UITableView()
    override func viewDidLoad() {
        super.viewDidLoad()
        hideKeyboardWhenTappedAround { (gesture) in
            gesture.delegate = self
        }
    }
}

extension ViewController: UIGestureRecognizerDelegate {
    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
        if touch.view?.isDescendant(of: tableView) == true {
            return false
        }
        
        return true
    }
}
```
or
```
hideKeyboardWhenTappedAround { (gesture) in
    gesture.cancelsTouchesInView = false
}
```