### PR TITLE
Add Codecov Yaml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  ignore:
+    - EZSwiftExtensionsExample/*
+    - EZSwiftExtensionsTests/*


### PR DESCRIPTION
Ignore `EZSwiftExtensionsTests` to calculate code coverage based on the `Source` files only.

https://github.com/codecov/support/wiki/Codecov-Yaml
https://codecov.io/gh/goktugyil/EZSwiftExtensions

<img width="1130" alt="screenshot" src="https://cloud.githubusercontent.com/assets/2032500/19624897/a2105716-993b-11e6-986f-4f98ee8e24da.png">
