### PR TITLE
Renamed UIColor.random()

### DIFF
--- a/Sources/UIColorExtensions.swift
+++ b/Sources/UIColorExtensions.swift
@@ -57,7 +57,6 @@ extension UIColor {
     public var alpha: CGFloat {
         var a: CGFloat = 0
         getRed(nil, green: nil, blue: nil, alpha: &a)
-        
         return a
     }
 

--- a/Sources/UIColorExtensions.swift
+++ b/Sources/UIColorExtensions.swift
@@ -61,7 +61,7 @@ extension UIColor {
     }
 
     /// EZSE: Returns random UIColor with random alpha(default: false)
-    public static func randomColor(_ randomAlpha: Bool = false) -> UIColor {
+    public static func random(_ randomAlpha: Bool = false) -> UIColor {
         let randomRed = CGFloat.random()
         let randomGreen = CGFloat.random()
         let randomBlue = CGFloat.random()

--- a/Sources/UIColorExtensions.swift
+++ b/Sources/UIColorExtensions.swift
@@ -57,11 +57,12 @@ extension UIColor {
     public var alpha: CGFloat {
         var a: CGFloat = 0
         getRed(nil, green: nil, blue: nil, alpha: &a)
+        
         return a
     }
 
     /// EZSE: Returns random UIColor with random alpha(default: false)
-    public static func random(_ randomAlpha: Bool = false) -> UIColor {
+    public static func random(randomAlpha: Bool = false) -> UIColor {
         let randomRed = CGFloat.random()
         let randomGreen = CGFloat.random()
         let randomBlue = CGFloat.random()

--- a/Sources/UIColoredView.swift
+++ b/Sources/UIColoredView.swift
@@ -11,7 +11,7 @@ import UIKit
 class UIColoredView: UIView {
     init() {
         super.init(frame: CGRect(x: 100, y: 100, w: 100, h: 100))
-        backgroundColor = UIColor.randomColor()
+        backgroundColor = UIColor.random()
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
I changed ``` UIColor.randomColor()``` to ```UIColor.random()``` following the Swift3 guidelines.

#### Before Swift3:
```
UIColor.blackColor()
UIColor.greenColor()
```

#### After Swift3:
```
UIColor.black
UIColor.green
```