### PR TITLE
Made hideKeyboardWhenTappedAround more swifty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
    - `addArrangedSubviews(_ views: UIView...)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/396) by *kirakik*
    - `init(distribution: UIStackViewDistribution, alignment: UIStackViewAlignment, axis: UILayoutConstraintAxis, spacing: CGFloat)` in [[PR]](https://github.com/goktugyil/         EZSwiftExtensions/pull/396) by *kirakik*
 
-### Modified extensions
-2. **UIViewController**
-
+### Deprecated/Renamed extensions
+1. **UIViewController**
+   - `public func hideKeyboardWhenTappedAround(cancelTouches: Bool = false)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/395) by *lfarah*
+   
 ## [Release 1.9]
 
 ### Fixed bugs 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
    - `addArrangedSubviews(_ views: UIView...)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/396) by *kirakik*
    - `init(distribution: UIStackViewDistribution, alignment: UIStackViewAlignment, axis: UILayoutConstraintAxis, spacing: CGFloat)` in [[PR]](https://github.com/goktugyil/         EZSwiftExtensions/pull/396) by *kirakik*
 
+### Modified extensions
+2. **UIViewController**
+
 ## [Release 1.9]
 
 ### Fixed bugs 

--- a/Sources/UIViewControllerExtensions.swift
+++ b/Sources/UIViewControllerExtensions.swift
@@ -125,14 +125,9 @@ extension UIViewController {
     }
     
     //EZSE: Makes the UIViewController register tap events and hides keyboard when clicked somewhere in the ViewController.
-    public func hideKeyboardWhenTappedAround() {
+    public func hideKeyboardWhenTappedAround(cancelTouches: Bool = false) {
         let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-    }
-    
-    public func hideKeyboardWhenTappedAroundAndCancelsTouchesInView() {
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.cancelsTouchesInView = cancelTouches
         view.addGestureRecognizer(tap)
     }
     
@@ -271,4 +266,13 @@ extension UIViewController {
         view.addSubview(imageView)
         view.sendSubview(toBack: imageView)
     }
+    
+    #if os(iOS)
+
+    @available(*, deprecated: 1.9)
+    public func hideKeyboardWhenTappedAroundAndCancelsTouchesInView() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        view.addGestureRecognizer(tap)
+    }
+    #endif
 }


### PR DESCRIPTION
* Added ```cancelTouches: Bool = false``` to ```hideKeyboardWhenTappedAround```.
* Deprecated ```hideKeyboardWhenTappedAroundAndCancelsTouchesInView```

fixes #383 
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [ ] Trivial change (doesn't require changelog)
