### PR TITLE
Fixed enum cases

### DIFF
--- a/EZSwiftExtensionsTests/UIFontTests.swift
+++ b/EZSwiftExtensionsTests/UIFontTests.swift
@@ -13,7 +13,7 @@ class UIFontTests: XCTestCase {
     
     let TEST_SIZE = CGFloat(10)
     
-    let TEST_FONT_TYPE = FontType.Bold
+    let TEST_FONT_TYPE = FontType.bold
     
     override func setUp() {
         super.setUp()
@@ -25,25 +25,25 @@ class UIFontTests: XCTestCase {
     
     func testHelveticaNeueFont() {
         let helveticaNeue = UIFont.HelveticaNeue(type: TEST_FONT_TYPE, size: TEST_SIZE)
-        XCTAssertEqual(helveticaNeue.fontName, FontName.HelveticaNeue.rawValue + "-" + TEST_FONT_TYPE.rawValue)
+        XCTAssertEqual(helveticaNeue.fontName, FontName.helveticaNeue.rawValue + "-" + TEST_FONT_TYPE.rawValue)
         XCTAssertEqual(helveticaNeue.pointSize, TEST_SIZE)
     }
     
     func testAvenirNextFont() {
-        let avenirNext = UIFont.AvenirNext(type: FontType.Bold, size: TEST_SIZE)
-        XCTAssertEqual(avenirNext.fontName, FontName.AvenirNext.rawValue + "-" + TEST_FONT_TYPE.rawValue)
+        let avenirNext = UIFont.AvenirNext(type: FontType.bold, size: TEST_SIZE)
+        XCTAssertEqual(avenirNext.fontName, FontName.avenirNext.rawValue + "-" + TEST_FONT_TYPE.rawValue)
         XCTAssertEqual(avenirNext.pointSize, TEST_SIZE)
     }
     
     func testAvenirNextRegularFont() {
         let avenirNextRegular = UIFont.AvenirNextRegular(size: TEST_SIZE)
-        XCTAssertEqual(avenirNextRegular.fontName, FontName.AvenirNext.rawValue + "-" + FontType.Regular.rawValue)
+        XCTAssertEqual(avenirNextRegular.fontName, FontName.avenirNext.rawValue + "-" + FontType.regular.rawValue)
         XCTAssertEqual(avenirNextRegular.pointSize, TEST_SIZE)
     }
     
     func testAvenirNextDemiBold() {
         let avenirNextDemiBold = UIFont.AvenirNextDemiBold(size: TEST_SIZE)
-        XCTAssertEqual(avenirNextDemiBold.fontName, FontName.AvenirNext.rawValue + "-" + FontType.DemiBold.rawValue)
+        XCTAssertEqual(avenirNextDemiBold.fontName, FontName.avenirNext.rawValue + "-" + FontType.demiBold.rawValue)
         XCTAssertEqual(avenirNextDemiBold.pointSize, TEST_SIZE)
     }
 }

--- a/EZSwiftExtensionsTests/UIFontTests.swift
+++ b/EZSwiftExtensionsTests/UIFontTests.swift
@@ -11,9 +11,9 @@ import XCTest
 
 class UIFontTests: XCTestCase {
     
-    let TEST_SIZE = CGFloat(10)
+    let testSize = CGFloat(10)
     
-    let TEST_FONT_TYPE = FontType.bold
+    let testFontType = FontType.bold
     
     override func setUp() {
         super.setUp()
@@ -24,27 +24,27 @@ class UIFontTests: XCTestCase {
     }
     
     func testHelveticaNeueFont() {
-        let helveticaNeue = UIFont.HelveticaNeue(type: TEST_FONT_TYPE, size: TEST_SIZE)
-        XCTAssertEqual(helveticaNeue.fontName, FontName.helveticaNeue.rawValue + "-" + TEST_FONT_TYPE.rawValue)
-        XCTAssertEqual(helveticaNeue.pointSize, TEST_SIZE)
+        let helveticaNeue = UIFont.HelveticaNeue(type: testFontType, size: testSize)
+        XCTAssertEqual(helveticaNeue.fontName, FontName.helveticaNeue.rawValue + "-" + testFontType.rawValue)
+        XCTAssertEqual(helveticaNeue.pointSize, testSize)
     }
     
     func testAvenirNextFont() {
-        let avenirNext = UIFont.AvenirNext(type: FontType.bold, size: TEST_SIZE)
-        XCTAssertEqual(avenirNext.fontName, FontName.avenirNext.rawValue + "-" + TEST_FONT_TYPE.rawValue)
-        XCTAssertEqual(avenirNext.pointSize, TEST_SIZE)
+        let avenirNext = UIFont.AvenirNext(type: FontType.bold, size: testSize)
+        XCTAssertEqual(avenirNext.fontName, FontName.avenirNext.rawValue + "-" + testFontType.rawValue)
+        XCTAssertEqual(avenirNext.pointSize, testSize)
     }
     
     func testAvenirNextRegularFont() {
-        let avenirNextRegular = UIFont.AvenirNextRegular(size: TEST_SIZE)
+        let avenirNextRegular = UIFont.AvenirNextRegular(size: testSize)
         XCTAssertEqual(avenirNextRegular.fontName, FontName.avenirNext.rawValue + "-" + FontType.regular.rawValue)
-        XCTAssertEqual(avenirNextRegular.pointSize, TEST_SIZE)
+        XCTAssertEqual(avenirNextRegular.pointSize, testSize)
     }
     
     func testAvenirNextDemiBold() {
-        let avenirNextDemiBold = UIFont.AvenirNextDemiBold(size: TEST_SIZE)
+        let avenirNextDemiBold = UIFont.AvenirNextDemiBold(size: testSize)
         XCTAssertEqual(avenirNextDemiBold.fontName, FontName.avenirNext.rawValue + "-" + FontType.demiBold.rawValue)
-        XCTAssertEqual(avenirNextDemiBold.pointSize, TEST_SIZE)
+        XCTAssertEqual(avenirNextDemiBold.pointSize, testSize)
     }
 }
 

--- a/Sources/UIFontExtensions.swift
+++ b/Sources/UIFontExtensions.swift
@@ -10,40 +10,40 @@ import UIKit
 
 /// EZSwiftExtensions
 public enum FontType: String {
-    case None = ""
-    case Regular = "Regular"
-    case Bold = "Bold"
-    case DemiBold = "DemiBold"
-    case Light = "Light"
-    case UltraLight = "UltraLight"
-    case Italic = "Italic"
-    case Thin = "Thin"
-    case Book = "Book"
-    case Roman = "Roman"
-    case Medium = "Medium"
-    case MediumItalic = "MediumItalic"
-    case CondensedMedium = "CondensedMedium"
-    case CondensedExtraBold = "CondensedExtraBold"
-    case SemiBold = "SemiBold"
-    case BoldItalic = "BoldItalic"
-    case Heavy = "Heavy"
+    case none = ""
+    case regular = "Regular"
+    case bold = "Bold"
+    case demiBold = "DemiBold"
+    case light = "Light"
+    case ultraLight = "UltraLight"
+    case italic = "Italic"
+    case thin = "Thin"
+    case book = "Book"
+    case roman = "Roman"
+    case medium = "Medium"
+    case mediumItalic = "MediumItalic"
+    case condensedMedium = "CondensedMedium"
+    case condensedExtraBold = "CondensedExtraBold"
+    case semiBold = "SemiBold"
+    case boldItalic = "BoldItalic"
+    case heavy = "Heavy"
 }
 
 /// EZSwiftExtensions
 public enum FontName: String {
-    case HelveticaNeue = "HelveticaNeue"
-    case Helvetica = "Helvetica"
-    case Futura = "Futura"
-    case Menlo = "Menlo"
-    case Avenir = "Avenir"
-    case AvenirNext = "AvenirNext"
-    case Didot = "Didot"
-    case AmericanTypewriter = "AmericanTypewriter"
-    case Baskerville = "Baskerville"
-    case Geneva = "Geneva"
-    case GillSans = "GillSans"
-    case SanFranciscoDisplay = "SanFranciscoDisplay"
-    case Seravek = "Seravek"
+    case helveticaNeue = "HelveticaNeue"
+    case helvetica = "Helvetica"
+    case futura = "Futura"
+    case menlo = "Menlo"
+    case avenir = "Avenir"
+    case avenirNext = "AvenirNext"
+    case didot = "Didot"
+    case americanTypewriter = "AmericanTypewriter"
+    case baskerville = "Baskerville"
+    case geneva = "Geneva"
+    case gillSans = "GillSans"
+    case sanFranciscoDisplay = "SanFranciscoDisplay"
+    case seravek = "Seravek"
 }
 
 extension UIFont {
@@ -73,22 +73,22 @@ extension UIFont {
 
     /// EZSwiftExtensions
     public class func HelveticaNeue(type: FontType, size: CGFloat) -> UIFont {
-        return Font(.HelveticaNeue, type: type, size: size)
+        return Font(.helveticaNeue, type: type, size: size)
     }
 
     /// EZSwiftExtensions
     public class func AvenirNext(type: FontType, size: CGFloat) -> UIFont {
-        return Font(.AvenirNext, type: type, size: size)
+        return Font(.avenirNext, type: type, size: size)
     }
 
     /// EZSwiftExtensions
     public class func AvenirNextDemiBold(size: CGFloat) -> UIFont {
-        return Font(.AvenirNext, type: .DemiBold, size: size)
+        return Font(.avenirNext, type: .demiBold, size: size)
     }
 
     /// EZSwiftExtensions
     public class func AvenirNextRegular(size: CGFloat) -> UIFont {
-        return Font(.AvenirNext, type: .Regular, size: size)
+        return Font(.avenirNext, type: .regular, size: size)
     }
 
     // MARK: Deprecated

--- a/Sources/UILabelExtensions.swift
+++ b/Sources/UILabelExtensions.swift
@@ -17,7 +17,7 @@ extension UILabel {
     /// EZSwiftExtensions
     public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat, fontSize: CGFloat) {
         self.init(frame: CGRect(x: x, y: y, width: w, height: h))
-        font = UIFont.HelveticaNeue(type: FontType.None, size: fontSize)
+        font = UIFont.HelveticaNeue(type: FontType.none, size: fontSize)
         backgroundColor = UIColor.clear
         clipsToBounds = true
         textAlignment = NSTextAlignment.left

--- a/Sources/UITextFieldExtensions.swift
+++ b/Sources/UITextFieldExtensions.swift
@@ -19,7 +19,7 @@ extension UITextField {
     /// textAlignment = Left, userInteractionEnabled = true, editable = false, scrollEnabled = false, font = ThemeFontName
     public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat, fontSize: CGFloat) {
         self.init(frame: CGRect(x: x, y: y, width: w, height: h))
-        font = UIFont.HelveticaNeue(type: FontType.None, size: fontSize)
+        font = UIFont.HelveticaNeue(type: FontType.none, size: fontSize)
         backgroundColor = UIColor.clear
         clipsToBounds = true
         textAlignment = NSTextAlignment.left

--- a/Sources/UITextViewExtensions.swift
+++ b/Sources/UITextViewExtensions.swift
@@ -19,7 +19,7 @@ extension UITextView {
     /// textAlignment = Left, userInteractionEnabled = true, editable = false, scrollEnabled = false, font = ThemeFontName
     public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat, fontSize: CGFloat) {
         self.init(frame: CGRect(x: x, y: y, width: w, height: h))
-        font = UIFont.HelveticaNeue(type: FontType.None, size: fontSize)
+        font = UIFont.HelveticaNeue(type: FontType.none, size: fontSize)
         backgroundColor = UIColor.clear
         clipsToBounds = true
         textAlignment = NSTextAlignment.left


### PR DESCRIPTION
Enum cases should be lower camel case in Swift3.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)
