### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ How Swift standard types and classes were supposed to work. A collection of usef
 Join our online chat at [![Gitter](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/EZSwiftExtensions/Lobby)
 - [Full Documentation via CocoaDocs](http://cocoadocs.org/docsets/EZSwiftExtensions/)
 
-##Example Usage
+## Example Usage
 
 Easily get an object at a specified index:
 ``` swift
@@ -115,7 +115,7 @@ ez.detectScreenShot { () -> () in
 }
 ```
 
-##Installation
+## Installation
 
 ### Manually (~10 seconds)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
