### PR TITLE
Fixed broken Array extension get(at:) (+test)

### DIFF
--- a/EZSwiftExtensionsTests/ArrayTests.swift
+++ b/EZSwiftExtensionsTests/ArrayTests.swift
@@ -21,11 +21,16 @@ class ArrayTests: XCTestCase {
     }
     
     func testGet_SubArray() {
-        setUp()
         XCTAssertEqual(numberArray.get(at: 2...4), [2,3,4])
         XCTAssertEqual(numberArray.get(at: -1...8), [0,1,2,3,4,5,1])
         XCTAssertEqual(numberArray.get(at: -1...3), [0,1,2,3])
         XCTAssertEqual(numberArray.get(at: 4...8), [4,5,1])
+        
+        let emptyArray = [Int]()
+        XCTAssertEqual(emptyArray.get(at: 0...0), [])
+        XCTAssertEqual(emptyArray.get(at: 1...3), [])
+        XCTAssertEqual(emptyArray.get(at: -3...(-1)), [])
+        XCTAssertEqual(emptyArray.get(at: -1...1), [])
     }
 
     func testAdding() {

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -22,13 +22,8 @@ extension Array {
 
     ///EZSE: Get a sub array from range of index
     public func get(at range: ClosedRange<Int>) -> Array {
-        var subArray = Array()
-        let lowerBound = range.lowerBound > 0 ? range.lowerBound : 0
-        let upperBound = range.upperBound > self.count - 1 ? self.count - 1 : range.upperBound
-        for index in lowerBound...upperBound {
-            subArray.append(self[index])
-        }
-        return subArray
+        let halfOpenClampedRange = Range(range).clamped(to: Range(indices))
+        return Array(self[halfOpenClampedRange])
     }
 
     /// EZSE: Checks if array contains at least 1 item which type is same with given element's type


### PR DESCRIPTION
The `get(at:)` extension previously led to a runtime exception when being called from empty arrays (`[]`), as the constructed local `ClosedRange` `lowerBound...upperBound` yielded the invalid `ClosedRange` `0...-1` for most supplied ranges.

Also extended the `testGet_SubArray()` test of `ArrayTests` to test the extension on empty arrays (which would've caught the case above).

Swiftlint @ ArrayExtensions OK.

I'm somewhat uncertain as to what boxes that apply in the checklist below for this commit, as I haven't added a new test, but have modified one. I'm marking it as trivial for now (refactoring/slightly extended test), but please advice me (/edit this msg) if this should be changed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [x] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)
