### PR TITLE
Refactoring some Array extensions

### DIFF
--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public func ==<T: Equatable>(lhs: [T]?, rhs: [T]?) -> Bool {
     switch (lhs, rhs) {
-    case (.some(let lhs), .some(let rhs)):
+    case let (lhs?, rhs?):
         return lhs == rhs
     case (.none, .none):
         return true
@@ -34,7 +34,7 @@ extension Array {
     /// EZSE: Checks if array contains at least 1 item which type is same with given element's type
     public func containsType<T>(of element: T) -> Bool {
         let elementType = type(of: element)
-        return first { type(of: $0) == elementType} != nil
+        return contains { type(of: $0) == elementType}
     }
 
     /// EZSE: Decompose an array to a tuple with first element and the rest
@@ -44,7 +44,7 @@ extension Array {
 
     /// EZSE: Iterates on each element of the array with its index. (Index, Element)
     public func forEachEnumerated(_ body: @escaping (_ offset: Int, _ element: Element) -> Void) {
-        self.enumerated().forEach(body)
+        enumerated().forEach(body)
     }
 
     /// EZSE: Gets the object at the specified index, if it exists.
@@ -61,22 +61,22 @@ extension Array {
     /// EZSE: Returns a random element from the array.
     public func random() -> Element? {
         guard count > 0 else { return nil }
-        let index = Int(arc4random_uniform(UInt32(self.count)))
+        let index = Int(arc4random_uniform(UInt32(count)))
         return self[index]
     }
 
     /// EZSE: Reverse the given index. i.g.: reverseIndex(2) would be 2 to the last
     public func reverseIndex(_ index: Int) -> Int? {
         guard index >= 0 && index < count else { return nil }
-        return Swift.max(self.count - 1 - index, 0)
+        return Swift.max(count - 1 - index, 0)
     }
 
     /// EZSE: Shuffles the array in-place using the Fisher-Yates-Durstenfeld algorithm.
     public mutating func shuffle() {
-        guard self.count > 1 else { return }
+        guard count > 1 else { return }
         var j: Int
-        for i in 0..<(self.count-2) {
-            j = Int(arc4random_uniform(UInt32(self.count - i)))
+        for i in 0..<(count-2) {
+            j = Int(arc4random_uniform(UInt32(count - i)))
             if i != i+j { swap(&self[i], &self[i+j]) }
         }
     }
@@ -95,7 +95,7 @@ extension Array {
 
     /// EZSE: Checks if test returns true for all the elements in self
     public func testAll(_ body: @escaping (Element) -> Bool) -> Bool {
-        return self.first { !body($0) } == nil
+        return !contains { !body($0) }
     }
 
     /// EZSE: Checks if all elements in the array are true or false
@@ -118,7 +118,7 @@ extension Array where Element: Equatable {
 
     /// EZSE: Returns the indexes of the object
     public func indexes(of element: Element) -> [Int] {
-        return self.enumerated().flatMap { ($0.element == element) ? $0.offset : nil }
+        return enumerated().flatMap { ($0.element == element) ? $0.offset : nil }
     }
 
     /// EZSE: Returns the last index of the object
@@ -128,17 +128,14 @@ extension Array where Element: Equatable {
 
     /// EZSE: Removes the first given object
     public mutating func removeFirst(_ element: Element) {
-        guard let index = self.index(of: element) else { return }
+        guard let index = index(of: element) else { return }
         self.remove(at: index)
     }
 
-    // EZSE: Removes all occurrences of the given object
+    /// EZSE: Removes all occurrences of the given object
     public mutating func removeAll(_ elements: Element...) {
-        for element in elements {
-            for index in self.indexes(of: element).reversed() {
-                self.remove(at: index)
-            }
-        }
+         // COW ensures no extra copy in case of no removed elements
+        self = filter { !elements.contains($0) }
     }
 
     /// EZSE: Difference of self and the input arrays.


### PR DESCRIPTION
Some minor refactoring of the `Array` extensions (I deemed these all to be minor enough to be chunked into a single refactoring commit and PR, please let me know if I should separate them into separate ones).

* Make use of `_?` sugar for pattern matching `.some(_)` case of `Optional`.

* Replaced calls to `first(where:)` (and subsequent equality testing vs `nil` and non-`nil` returns) with `contains(where:)`. As we only test for existence and don't actually make use of the possible existing element (conditionally returned by `first(where:)`), the latter should be preferred.

* Refactored `removeAll(_:)` to use a single `filter(_:)` rather than nested mutation of `self`. Both approaches are `O(n^2)`, but using `filter(_:)` will result in fewer mutations (and possible re-allocations) of `self`. The refactored implementation can also be easily overloaded to use a `Set` of the supplied `Element...` parameter for `O(1)` lookup for the more specific case of `Element: Hashable`, which would reduce the complexity of `removeAll(_:)` to `O(n)` for `Hashable` elements. I can push a PR for this overload at a later time, given that this PR is accepted.

* Removed redundant `self` prefix for accessing properties and methods of `Array`. This refactoring has not been not applied for the `get(at:)` method, as I have PR up fully refactoring it.

Swiftlint @ ArrayExtensions OK.

As for my other PR, please let me know if I'm off in the checklist below, or if I've missed any best practice/guidelines w.r.t. pushing PRs to EZSwiftExtensions!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)