### PR TITLE
Added two overloads for the 'removeAll(_:)' extension of 'Array'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
    - `addArrangedSubviews(_ views: UIView...)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/396) by *kirakik*
    - `init(distribution: UIStackViewDistribution, alignment: UIStackViewAlignment, axis: UILayoutConstraintAxis, spacing: CGFloat)` in [[PR]](https://github.com/goktugyil/         EZSwiftExtensions/pull/396) by *kirakik*
 
+### Added extensions
+1. **Array**
+   - `removeAll(_ elements: [Element])` (new overload) for `Equatable` elements in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/416) by *dfrib*
+   - `removeAll(_ elements: [Element])` (new overload) for `Hashable` elements in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/416) by *dfrib*
+
 ### Deprecated/Renamed extensions
 1. **UIViewController**
    - `public func hideKeyboardWhenTappedAround(cancelTouches: Bool = false)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/395) by *lfarah*

--- a/EZSwiftExtensionsTests/ArrayTests.swift
+++ b/EZSwiftExtensionsTests/ArrayTests.swift
@@ -63,13 +63,46 @@ class ArrayTests: XCTestCase {
         XCTAssertEqual(numberArray, compareArray)
     }
 
-    func testRemoveObjects() {
+    struct NonHashable : Equatable {
+        let val: Int
+        init(_ val: Int) { self.val = val }
+        
+        static func ==(lhs: NonHashable, rhs: NonHashable) -> Bool {
+            return lhs.val == rhs.val
+        }
+    }
+
+    func testRemoveObjectsByArray() {
+        let removeArrayA = [123, 45] // none present in target
+        let removeArrayB = [1, 3]    // both present in target
+
+        // 'removeAll' overload for Hashable elements
+        let copyArray = numberArray
+        numberArray.removeAll(removeArrayA)
+        XCTAssertEqual(numberArray, copyArray)
+
+        let compareArray = [0, 2, 4, 5]
+        numberArray.removeAll(removeArrayB)
+        XCTAssertEqual(numberArray, compareArray)
+
+        // 'removeAll' overload for Equatable but not Hashable elements
+        var nonHashableArray = numberArray.map(NonHashable.init)
+        let nonHashableCopyArray = nonHashableArray
+        nonHashableArray.removeAll(removeArrayA.map(NonHashable.init))
+        XCTAssertEqual(nonHashableArray, nonHashableCopyArray)
+
+        let nonHashableCompareArray = compareArray.map(NonHashable.init)
+        nonHashableArray.removeAll(removeArrayB.map(NonHashable.init))
+        XCTAssertEqual(nonHashableArray, nonHashableCompareArray)
+    }
+
+    func testRemoveObjectsByVariadic() {
         let copyArray = numberArray
         numberArray.removeAll(12345)
         XCTAssertEqual(numberArray, copyArray)
 
-        let compareArray = [0, 2, 3, 4, 5]
-        numberArray.removeAll(1)
+        let compareArray = [0, 2, 4, 5]
+        numberArray.removeAll(1, 3)
         XCTAssertEqual(numberArray, compareArray)
     }
 

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -132,13 +132,15 @@ extension Array where Element: Equatable {
         self.remove(at: index)
     }
 
-    // EZSE: Removes all occurrences of the given object
+    /// EZSE: Removes all occurrences of the given object(s)
     public mutating func removeAll(_ elements: Element...) {
-        for element in elements {
-            for index in self.indexes(of: element).reversed() {
-                self.remove(at: index)
-            }
-        }
+        removeAll(elements)
+    }
+
+    /// EZSE: Removes all occurrences of the given object(s)
+    public mutating func removeAll(_ elements: [Element]) {
+        // COW ensures no extra copy in case of no removed elements
+        self = filter { !elements.contains($0) }
     }
 
     /// EZSE: Difference of self and the input arrays.
@@ -198,6 +200,16 @@ extension Array where Element: Equatable {
     /// EZSE: Returns an array consisting of the unique elements in the array
     public func unique() -> Array {
         return reduce([]) { $0.contains($1) ? $0 : $0 + [$1] }
+    }
+}
+
+extension Array where Element: Hashable {
+
+    /// EZSE: Removes all occurrences of the given object(s)
+    public mutating func removeAll(_ elements: [Element]) {
+        let elementsSet = Set(elements)
+        // COW ensures no extra copy in case of no removed elements
+        self = filter { !elementsSet.contains($0) }
     }
 }
 


### PR DESCRIPTION
**Summary**
Added two overloads for the `removeAll(_:)` extension of `Array`:
* One for an array parameter rather than a variadic one.
* Another one for an array parameter but for a more specific overload; elements conforming to `Hashable`.

Updated the existing variadic overload to simply call the new array one.

Extended the existing test `testRemoveObjects()` into two: one testing the
single variadic overload and one testing the two new array overloads.

Swiftlint @ ArrayExtensions OK.

Please advise me if I'm missing some PR best practices/guidelines for EZSE.

**Background & Motivation**
The existing implementation will for similarily growing size of `self` and the supplied variadic parameter have `O(n^2)` complexity. This isn't any limitation at all for the variadic overload, as the number of supplied elements will be limited ("constant"). For the new array overload, however, a custom-sized array can be supplied as a parameter, in which case it could be useful to make use of the (amortized) `O(1)` lookup for `Hashable` elements in a `HashedCollection` (e.g. `Set`). The `Hashable` overload will, for each element in `self`, perform an (amortized) `O(1)` lookup for the elements in the supplied array, at the cost of a single `Set` instantation of the array parameter, such that the `Hashable` overload will have `O(n)` complexity (for similarily growing size of `self` and supplied array parameter).

**Impact**
There should be no usage impact on existing use of the `removeAll(_:)` method: only a new array parameter overload available for use.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [x] New Extension
- [x] New Test
- [x] Changed more than one extension, but all changes are related
- [ ] Trivial change (doesn't require changelog)