### PR TITLE
feat: change shakeViewForTimes function

### DIFF
--- a/Sources/UIViewExtensions.swift
+++ b/Sources/UIViewExtensions.swift
@@ -584,16 +584,13 @@ extension UIView {
 extension UIView {
     ///EZSE: Shakes the view for as many number of times as given in the argument.
     public func shakeViewForTimes(_ times: Int) {
-        let anim = CAKeyframeAnimation(keyPath: "transform")
-        anim.values = [
-            NSValue(caTransform3D: CATransform3DMakeTranslation(-5, 0, 0 )),
-            NSValue(caTransform3D: CATransform3DMakeTranslation( 5, 0, 0 ))
-        ]
-        anim.autoreverses = true
-        anim.repeatCount = Float(times)
-        anim.duration = 7/100
-
-        self.layer.add(anim, forKey: nil)
+        let animation = CABasicAnimation(keyPath: "position")
+        animation.duration = 0.07
+        animation.repeatCount = Float(times)
+        animation.autoreverses = true
+        animation.fromValue = CGPoint(x: self.frame.midX - 10, y: self.frame.midY)
+        animation.toValue = CGPoint(x: self.frame.midX + 10, y: self.frame.midY)
+        self.layer.add(animation, forKey: "position")
     }
 }
 


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)

The previous implementation of `shakeViewForTimes(_:)` causes the view to be misaligned after the animation has ended. This implementation does not.

I'm not sure how to test this and there were no previous tests to refer to 😅 