### PR TITLE
Adding fix to ensure removeAll() from std lib does not clash with

### DIFF
--- a/EZSwiftExtensionsTests/ArrayTests.swift
+++ b/EZSwiftExtensionsTests/ArrayTests.swift
@@ -76,6 +76,17 @@ class ArrayTests: XCTestCase {
             return lhs.val == rhs.val
         }
     }
+    
+    func testRemoveAllSanityFromStdLib() {
+        var rmArray = [1, 2, 3, 4, 5]
+        
+        // This test case is to ensure that remove all from std lib is not conflicted.
+        // The method called here is from std lib. If there is a compile time failure, 
+        // our code is coflicting with stdlib.
+        rmArray.removeAll()
+        
+        XCTAssertTrue(rmArray.isEmpty)
+    }
 
     func testRemoveObjectsByArray() {
         let removeArrayA = [123, 45] // none present in target
@@ -109,6 +120,22 @@ class ArrayTests: XCTestCase {
         let compareArray = [0, 2, 4, 5]
         numberArray.removeAll(1, 3)
         XCTAssertEqual(numberArray, compareArray)
+    }
+    
+    func testRemoveObjectByVariadicWithFirstElement() {
+        var noChangeArray = [0, 2, 4, 5]
+        let nilFirstElem:Int? = nil
+        noChangeArray.removeAll(nilFirstElem, 1, 3)
+        XCTAssertEqual(noChangeArray, noChangeArray)
+        
+        var changedArrayWithNilFirstElement = [0, 2, 4, 5]
+        changedArrayWithNilFirstElement.removeAll(nilFirstElem, 2, 4)
+        XCTAssertEqual(changedArrayWithNilFirstElement, [0, 5])
+        
+        var changedArray = [0, 2, 4, 5, 6]
+        let firstElement = 0;
+        changedArray.removeAll(firstElement, 2, 4)
+        XCTAssertEqual(changedArray, [5, 6])
     }
 
     func testContainsInstanceOf() {

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -128,9 +128,17 @@ extension Array where Element: Equatable {
         self.remove(at: index)
     }
 
-    /// EZSE: Removes all occurrences of the given object(s)
-    public mutating func removeAll(_ elements: Element...) {
-        removeAll(elements)
+    /// EZSE: Removes all occurrences of the given object(s), at least one entry is needed.
+    public mutating func removeAll(_ firstElement: Element?, _ elements: Element...) {
+        var removeAllArr = [Element]()
+        
+        if let firstElementVal = firstElement {
+            removeAllArr.append(firstElementVal)
+        }
+        
+        elements.forEach({element in removeAllArr.append(element)})
+        
+        removeAll(removeAllArr)
     }
 
     /// EZSE: Removes all occurrences of the given object(s)


### PR DESCRIPTION
EZSwiftExtensions. Also adding test cases to ensure that never
happens again.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [x] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)
