### PR TITLE
Safe array extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 1. **Double**
    - `**?(lhs:Double, rhs:Double)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/443) by *Khalian*
 
+2. **Array**
+   - `public subscript (safe index: Index)` in [[PR]](https://github.com/goktugyil/EZSwiftExtensions/pull/445) by *lfarah*
+
 ## [Release 1.10]
 
 ### New platform added. 

--- a/EZSwiftExtensionsTests/ArrayTests.swift
+++ b/EZSwiftExtensionsTests/ArrayTests.swift
@@ -32,6 +32,14 @@ class ArrayTests: XCTestCase {
         XCTAssertEqual(emptyArray.get(at: -3...(-1)), [])
         XCTAssertEqual(emptyArray.get(at: -1...1), [])
     }
+    
+    func testSafeIndex() {
+        
+        let optionalNumber: Int? = 3
+        XCTAssertEqual(numberArray[safe: 3], optionalNumber)
+        XCTAssertNotEqual(numberArray[safe: 4], 3)
+        XCTAssertNil(numberArray[safe: 10])
+    }
 
     func testAdding() {
         numberArray.insertFirst(9)

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -219,7 +219,7 @@ extension Array where Element: Hashable {
 
 extension Collection where Indices.Iterator.Element == Index {
     
-    /// Returns the element at the specified index iff it is within bounds, otherwise nil.
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
     public subscript (safe index: Index) -> Generator.Element? {
         return indices.contains(index) ? self[index] : nil
     }

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -217,6 +217,14 @@ extension Array where Element: Hashable {
     }
 }
 
+extension Collection where Indices.Iterator.Element == Index {
+    
+    /// Returns the element at the specified index iff it is within bounds, otherwise nil.
+    public subscript (safe index: Index) -> Generator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}
+
 // MARK: - Deprecated 1.8
 
 extension Array {


### PR DESCRIPTION
A common crash around swift is to get to subscript an array with a bigger index than the number of array's objects. This extension fixes that by giving an optional value.

This code is from @nkukushkin's [StackOverflow's answer](https://stackoverflow.com/a/30593673/2938877)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [x] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [ ] Trivial change (doesn't require changelog)
