### PR TITLE
Not showing multiple file error bug

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -18,7 +18,7 @@ if git.commits.any? { |c| c.message =~ /^Merge branch '#{github.branch_for_base}
 end
 
 # Restrict changing only one extension per PR
-if git.modified_files.grep(/^Sources\//).count > 1
+if (git.modified_files.grep(/^Sources\//).count > 1) && (github.pr_body.include? "- [ ] Changed more than one extension, but all changes are related")
 	fail("Please, modify only one extension per pull request.")
 end
 


### PR DESCRIPTION
When user selects the following, Danger can't show the multiple file error:
- [ ] Changed more than one extension, but all changes are related

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)
