### PR TITLE
Making the calendar in timepassed autoupdating. This way consumers will

### DIFF
--- a/Sources/DateExtensions.swift
+++ b/Sources/DateExtensions.swift
@@ -103,7 +103,7 @@ extension Date {
     /// EZSE: Easy creation of time passed String. Can be Years, Months, days, hours, minutes or seconds
     public func timePassed() -> String {
         let date = Date()
-        let calendar = Calendar.current
+        let calendar = Calendar.autoupdatingCurrent
         let components = (calendar as NSCalendar).components([.year, .month, .day, .hour, .minute, .second], from: self, to: date, options: [])
         var str: String
         


### PR DESCRIPTION
not see discrepancies in time passed for them during changing timezones
and honors the users preferred calendar.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [ ] New Test
- [ ] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)
