### PR TITLE
Swift4finalmergecandidate minor fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.2
+osx_image: xcode9.3
 language: objective-c
 rvm: 2.2.2
 cache: cocoapods

--- a/EZSwiftExtensions.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensions.xcodeproj/project.pbxproj
@@ -1498,7 +1498,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.gbf.EZSwiftExtensions.EZSwiftExtensions;
 				PRODUCT_NAME = EZSwiftExtensions;
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1519,7 +1519,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.gbf.EZSwiftExtensions.EZSwiftExtensions;
 				PRODUCT_NAME = EZSwiftExtensions;
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/EZSwiftExtensions.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensions.xcodeproj/project.pbxproj
@@ -1532,7 +1532,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gbf.EZSwiftExtensions.EZSwiftExtensionsTests;
 				PRODUCT_NAME = EZSwiftExtensionsTest;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "";
 			};
@@ -1545,7 +1545,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gbf.EZSwiftExtensions.EZSwiftExtensionsTests;
 				PRODUCT_NAME = EZSwiftExtensionsTest;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "";
 			};

--- a/EZSwiftExtensionsTests/StringTests.swift
+++ b/EZSwiftExtensionsTests/StringTests.swift
@@ -334,6 +334,8 @@ class StringTests: XCTestCase {
         let expectedResult = 5
         
         XCTAssertEqual(testString.getIndexOf("L"), expectedResult)
+        
+        XCTAssertEqual(testString.getIndexOf("X"), nil)
     }
     
     func testCount() {

--- a/Sources/ArrayExtensions.swift
+++ b/Sources/ArrayExtensions.swift
@@ -114,7 +114,7 @@ extension Array where Element: Equatable {
 
     /// EZSE: Returns the indexes of the object
     public func indexes(of element: Element) -> [Int] {
-        return enumerated().flatMap { ($0.element == element) ? $0.offset : nil }
+        return enumerated().compactMap { ($0.element == element) ? $0.offset : nil }
     }
 
     /// EZSE: Returns the last index of the object

--- a/Sources/BlockSwipe.swift
+++ b/Sources/BlockSwipe.swift
@@ -18,7 +18,8 @@ open class BlockSwipe: UISwipeGestureRecognizer {
         super.init(target: target, action: action)
     }
 
-    public convenience init (direction: UISwipeGestureRecognizerDirection,
+    public convenience init (
+        direction: UISwipeGestureRecognizerDirection,
         fingerCount: Int = 1,
         action: ((UISwipeGestureRecognizer) -> Void)?) {
             self.init()

--- a/Sources/CollectionsExtension.swift
+++ b/Sources/CollectionsExtension.swift
@@ -27,7 +27,6 @@ extension Collection {
         return res
     }
 
-    
     /// EZSE : Helper method to get an array of collection indices
     private func indicesArray() -> [Self.Index] {
         var indicesArray: [Self.Index] = []

--- a/Sources/DictionaryExtensions.swift
+++ b/Sources/DictionaryExtensions.swift
@@ -28,7 +28,7 @@ extension Dictionary {
 
     /// EZSE: Intersection of self and the input dictionaries.
     /// Two dictionaries are considered equal if they contain the same [key: value] copules.
-    public func intersection<K, V: Equatable>(_ dictionaries: [K: V]...) -> [K: V] {
+    public func intersection<K: Equatable, V: Equatable>(_ dictionaries: [K: V]...) -> [K: V] {
         //  Casts self from [Key: Value] to [K: V]
         let filtered = mapFilter { (item, value) -> (K, V)? in
             if let item = item as? K, let value = value as? V {
@@ -122,7 +122,10 @@ extension Dictionary {
 
     /// EZSE: Unserialize JSON string into Dictionary
     public static func constructFromJSON (json: String) -> Dictionary? {
-        if let data = (try? JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8, allowLossyConversion: true)!, options: JSONSerialization.ReadingOptions.mutableContainers)) as? Dictionary {
+        if let data = (try? JSONSerialization.jsonObject(
+            with: json.data(using: String.Encoding.utf8,
+                            allowLossyConversion: true)!,
+            options: JSONSerialization.ReadingOptions.mutableContainers)) as? Dictionary {
             return data
         } else {
             return nil
@@ -174,6 +177,6 @@ public func & <K, V: Equatable> (first: [K: V], second: [K: V]) -> [K: V] {
 }
 
 /// EZSE: Union operator
-public func | <K, V> (first: [K: V], second: [K: V]) -> [K: V] {
+public func | <K: Hashable, V> (first: [K: V], second: [K: V]) -> [K: V] {
     return first.union(second)
 }

--- a/Sources/EZSwiftFunctions.swift
+++ b/Sources/EZSwiftFunctions.swift
@@ -202,7 +202,7 @@ public struct ez {
     /// EZSE: Calls action when a screen shot is taken
     public static func detectScreenShot(_ action: @escaping () -> Void) {
         let mainQueue = OperationQueue.main
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationUserDidTakeScreenshot, object: nil, queue: mainQueue) { notification in
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationUserDidTakeScreenshot, object: nil, queue: mainQueue) { _ in
             // executes after screenshot
             action()
         }
@@ -254,7 +254,10 @@ public struct ez {
     }
 
     /// EZSE: Runs every second, to cancel use: timer.invalidate()
-    @discardableResult public static func runThisEvery(seconds: TimeInterval, startAfterSeconds: TimeInterval, handler: @escaping (CFRunLoopTimer?) -> Void) -> Timer {
+    @discardableResult public static func runThisEvery(
+        seconds: TimeInterval,
+        startAfterSeconds: TimeInterval,
+        handler: @escaping (CFRunLoopTimer?) -> Void) -> Timer {
         let fireDate = startAfterSeconds + CFAbsoluteTimeGetCurrent()
         let timer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, fireDate, seconds, 0, 0, handler)
         CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer, CFRunLoopMode.commonModes)
@@ -341,7 +344,7 @@ public struct ez {
                 json = nil
             }
 
-            if let _ = error {
+            if error != nil {
                 return nil
             } else {
                 return json
@@ -360,7 +363,7 @@ public struct ez {
 
         URLSession.shared.dataTask(
             with: URLRequest(url: requestURL),
-            completionHandler: { data, response, err in
+            completionHandler: { data, _, err in
                 if let e = err {
                     error?(e as NSError)
                 } else {

--- a/Sources/EZSwiftFunctions.swift
+++ b/Sources/EZSwiftFunctions.swift
@@ -78,7 +78,7 @@ public struct ez {
 
     /// EZSE: Returns true if its simulator and not a device //TODO: Add to readme
     public static var isSimulator: Bool {
-    #if (arch(i386) || arch(x86_64)) && os(iOS)
+    #if targetEnvironment(simulator)
         return true
     #else
         return false
@@ -87,7 +87,7 @@ public struct ez {
 
     /// EZSE: Returns true if its on a device and not a simulator //TODO: Add to readme
     public static var isDevice: Bool {
-    #if (arch(i386) || arch(x86_64)) && os(iOS)
+    #if targetEnvironment(simulator)
         return false
     #else
         return true
@@ -202,7 +202,7 @@ public struct ez {
     /// EZSE: Calls action when a screen shot is taken
     public static func detectScreenShot(_ action: @escaping () -> Void) {
         let mainQueue = OperationQueue.main
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationUserDidTakeScreenshot, object: nil, queue: mainQueue) { _ in
+        _ = NotificationCenter.default.addObserver(forName: NSNotification.Name.UIApplicationUserDidTakeScreenshot, object: nil, queue: mainQueue) { _ in
             // executes after screenshot
             action()
         }

--- a/Sources/StringExtensions.swift
+++ b/Sources/StringExtensions.swift
@@ -255,7 +255,7 @@ extension String {
     public var countofParagraphs: Int {
         let regex = try? NSRegularExpression(pattern: "\\n", options: NSRegularExpression.Options())
         let str = self.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        return (regex?.numberOfMatches(in: str, options: NSRegularExpression.MatchingOptions(), range: NSRange(location:0, length: str.length)) ?? -1) + 1
+        return (regex?.numberOfMatches(in: str, options: NSRegularExpression.MatchingOptions(), range: NSRange(location: 0, length: str.length)) ?? -1) + 1
     }
     
     internal func rangeFromNSRange(_ nsRange: NSRange) -> Range<String.Index>? {
@@ -285,10 +285,7 @@ extension String {
     
     /// EZSE: Returns if String is a number
     public func isNumber() -> Bool {
-        if let _ = NumberFormatter().number(from: self) {
-            return true
-        }
-        return false
+        return NumberFormatter().number(from: self) != nil ? true : false
     }
     
     /// EZSE: Extracts URLS from String
@@ -304,8 +301,10 @@ extension String {
         let text = self
         
         if let detector = detector {
-            detector.enumerateMatches(in: text, options: [], range: NSRange(location: 0, length: text.count), using: {
-                (result: NSTextCheckingResult?, flags: NSRegularExpression.MatchingFlags, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
+            detector.enumerateMatches(in: text,
+                                      options: [],
+                                      range: NSRange(location: 0, length: text.count),
+                                      using: { (result: NSTextCheckingResult?, _, _) -> Void in
                 if let result = result, let url = result.url {
                     urls.append(url)
                 }
@@ -358,10 +357,8 @@ extension String {
     
     ///EZSE: Returns the first index of the occurency of the character in String
     public func getIndexOf(_ char: Character) -> Int? {
-        for (index, c) in self.enumerated() {
-            if c == char {
-                return index
-            }
+        for (index, c) in self.enumerated() where c == char {
+            return index
         }
         return nil
     }
@@ -410,7 +407,7 @@ extension String {
             attrib.updateValue(paragraphStyle, forKey: NSAttributedStringKey.paragraphStyle)
         }
         let size = CGSize(width: width, height: CGFloat(Double.greatestFiniteMagnitude))
-        return ceil((self as NSString).boundingRect(with: size, options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes:attrib, context: nil).height)
+        return ceil((self as NSString).boundingRect(with: size, options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attrib, context: nil).height)
     }
     
     #endif

--- a/Sources/UIButtonExtensions.swift
+++ b/Sources/UIButtonExtensions.swift
@@ -18,7 +18,7 @@ extension UIButton {
 		addTarget(target, action: action, for: UIControlEvents.touchUpInside)
 	}
 
-	/// EZSwiftExtensions
+	/// EZSwiftExtensions: Set a background color for the button.
 	public func setBackgroundColor(_ color: UIColor, forState: UIControlState) {
 		UIGraphicsBeginImageContext(CGSize(width: 1, height: 1))
 		UIGraphicsGetCurrentContext()?.setFillColor(color.cgColor)

--- a/Sources/UIFontExtensions.swift
+++ b/Sources/UIFontExtensions.swift
@@ -33,19 +33,19 @@ public enum FontType: String {
 
 /// EZSwiftExtensions
 public enum FontName: String {
-    case HelveticaNeue = "HelveticaNeue"
-    case Helvetica = "Helvetica"
-    case Futura = "Futura"
-    case Menlo = "Menlo"
-    case Avenir = "Avenir"
-    case AvenirNext = "AvenirNext"
-    case Didot = "Didot"
-    case AmericanTypewriter = "AmericanTypewriter"
-    case Baskerville = "Baskerville"
-    case Geneva = "Geneva"
-    case GillSans = "GillSans"
-    case SanFranciscoDisplay = "SanFranciscoDisplay"
-    case Seravek = "Seravek"
+    case HelveticaNeue
+    case Helvetica
+    case Futura
+    case Menlo
+    case Avenir
+    case AvenirNext
+    case Didot
+    case AmericanTypewriter
+    case Baskerville
+    case Geneva
+    case GillSans
+    case SanFranciscoDisplay
+    case Seravek
 }
 
 extension UIFont {

--- a/Sources/UIImageExtensions.swift
+++ b/Sources/UIImageExtensions.swift
@@ -13,7 +13,7 @@ import UIKit
 extension UIImage {
     
     /// EZSE: Returns base64 string
-    var base64: String {
+    public var base64: String {
         return UIImageJPEGRepresentation(self, 1.0)!.base64EncodedString()
     }
     

--- a/Sources/UISliderExtensions.swift
+++ b/Sources/UISliderExtensions.swift
@@ -15,7 +15,7 @@ extension UISlider {
     public func setValue(_ value: Float, duration: Double) {
       UIView.animate(withDuration: duration, animations: { () -> Void in
         self.setValue(self.value, animated: true)
-        }, completion: { (bool) -> Void in
+        }, completion: { (_) -> Void in
           UIView.animate(withDuration: duration, animations: { () -> Void in
             self.setValue(value, animated: true)
             }, completion: nil)

--- a/Sources/UITextFieldExtensions.swift
+++ b/Sources/UITextFieldExtensions.swift
@@ -5,6 +5,7 @@
 //  Created by Wang Yu on 6/26/16.
 //  Copyright © 2016 Goktug Yilmaz. All rights reserved.
 //
+// swiftlint:disable line_length
 
 #if os(iOS) || os(tvOS)
 
@@ -16,7 +17,7 @@ extension UITextField {
     
     /// EZSwiftExtensions: Automatically sets these values: backgroundColor = clearColor, textColor = ThemeNicknameColor, clipsToBounds = true,
     /// textAlignment = Left, userInteractionEnabled = true, editable = false, scrollEnabled = false, font = ThemeFontName
-    public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat, fontSize: CGFloat = 20) {
+    public convenience init(x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat, fontSize: CGFloat = 17) {
         self.init(frame: CGRect(x: x, y: y, width: w, height: h))
         font = UIFont.HelveticaNeue(type: FontType.None, size: fontSize)
         backgroundColor = UIColor.clear
@@ -73,14 +74,14 @@ extension UITextField {
     /// EZSE: Validation of email format based on https://stackoverflow.com/questions/201323/using-a-regular-expression-to-validate-an-email-address and https://stackoverflow.com/questions/2049502/what-characters-are-allowed-in-an-email-address
     // TODO match String.isEmail method
     func validateEmail() -> Bool {
-        let emailTest = NSPredicate(format:"SELF MATCHES %@", UITextField.emailRegex)
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", UITextField.emailRegex)
         return emailTest.evaluate(with: self.text)
     }
     
     /// EZSE: Validation of digits only
     func validateDigits() -> Bool {
         let digitsRegEx = "[0-9]*"
-        let digitsTest = NSPredicate(format:"SELF MATCHES %@", digitsRegEx)
+        let digitsTest = NSPredicate(format: "SELF MATCHES %@", digitsRegEx)
         return digitsTest.evaluate(with: self.text)
     }
 }

--- a/Sources/UIViewControllerExtensions.swift
+++ b/Sources/UIViewControllerExtensions.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Goktug Yilmaz on 15/07/15.
 //  Copyright (c) 2015 Goktug Yilmaz. All rights reserved.
-// swiftlint:disable trailing_whitespace
 
 #if os(iOS) || os(tvOS)
 
@@ -231,7 +230,7 @@ extension UIViewController {
     }
 
     /// EZSE: Hide or show navigation bar
-    public var isNavBarHidden:Bool {
+    public var isNavBarHidden: Bool {
         get {
             return (navigationController?.isNavigationBarHidden)!
         }

--- a/Sources/UIViewExtensions.swift
+++ b/Sources/UIViewExtensions.swift
@@ -449,7 +449,7 @@ extension UIView {
         setScale(x: 0.9, y: 0.9)
         UIView.animate(withDuration: 0.05, delay: 0, options: .allowUserInteraction, animations: {[weak self] in
             self?.setScale(x: 1, y: 1)
-        }, completion: { (bool) in })
+        }, completion: { (_) in })
     }
 }
 

--- a/Sources/URLExtensions.swift
+++ b/Sources/URLExtensions.swift
@@ -7,7 +7,6 @@
 //  Copyright (c) 2016 Goktug Yilmaz. All rights reserved.
 //
 // swiftlint:disable line_length
-// swiftlint:disable trailing_whitespace
 
 #if os(iOS) || os(tvOS)
 
@@ -33,7 +32,7 @@ extension URL {
         let request = NSMutableURLRequest(url: self, cachePolicy: NSURLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: timeoutInterval)
         request.httpMethod = "HEAD"
         request.setValue("", forHTTPHeaderField: "Accept-Encoding")
-        URLSession.shared.dataTask(with: request as URLRequest) { (data, response, error) in
+        URLSession.shared.dataTask(with: request as URLRequest) { (_, response, _) in
             let contentLength: Int64 = response?.expectedContentLength ?? NSURLSessionTransferSizeUnknown
             DispatchQueue.global(qos: .default).async(execute: {
                 completionHandler(contentLength)


### PR DESCRIPTION
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [x] New Test
- [x] Changed more than one extension, but all changes are related
- [x] Trivial change (doesn't require changelog)

This PR mainly reverts some improper changes back to original, and fixes couple of warnings based on #476 .

Some changes explained as below.

- `SWIFT_SWIFT3_OBJC_INFERENCE` is set to `Default` as suggested [here](https://stackoverflow.com/questions/44379348/the-use-of-swift-3-objc-inference-in-swift-4-mode-is-deprecated)
- The  `Hashable` and `Equatable` thing seems like an [issue](https://bugs.swift.org/browse/SR-5072) with XCode 9.2 compiler, I've revert them back and update to 9.3 for CI. 
- `#if targetEnvironment(simulator)` is suggested to replace `#if (arch(i386) || arch(x86_64)) && os(iOS)` by compiler. [Ref](https://github.com/apple/swift-evolution/blob/master/proposals/0190-target-environment-platform-condition.md)
- Block based `NotificationCenter.​addObserver​(forName:​object:​queue:​using:)` is warned by lint requiring an object to store the returned result, so that it can be removed later. I simply store it to an empty object, but [here](https://oleb.net/blog/2018/01/notificationcenter-removeobserver/) is a better solution.
