### PR TITLE
Overloaded -timePassed method with language agnostic implementation

### DIFF
--- a/EZSwiftExtensions.xcodeproj/project.pbxproj
+++ b/EZSwiftExtensions.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		0B96F02E1E2FD32500236DDE /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96F02C1E2FD32000236DDE /* UIEdgeInsets.swift */; };
 		0B96F0301E2FD33C00236DDE /* UIEdgeInsetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96F02F1E2FD33C00236DDE /* UIEdgeInsetsTests.swift */; };
 		0B96F0311E2FD33C00236DDE /* UIEdgeInsetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96F02F1E2FD33C00236DDE /* UIEdgeInsetsTests.swift */; };
+		2D919FD0212FC9440024A3AE /* TimePassed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D919FCF212FC9440024A3AE /* TimePassed.swift */; };
+		2D919FD1212FC9440024A3AE /* TimePassed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D919FCF212FC9440024A3AE /* TimePassed.swift */; };
+		2D919FD2212FC9440024A3AE /* TimePassed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D919FCF212FC9440024A3AE /* TimePassed.swift */; };
 		31F868DB1C2B6E5E00542250 /* DoubleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F868DA1C2B6E5E00542250 /* DoubleExtensions.swift */; };
 		50AD20191DDCE6FF00A5A863 /* FileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AD20181DDCE6FF00A5A863 /* FileManagerTests.swift */; };
 		50AD201A1DDCE6FF00A5A863 /* FileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AD20181DDCE6FF00A5A863 /* FileManagerTests.swift */; };
@@ -354,6 +357,7 @@
 		0B96C3CD1C8688CB00BB2A3B /* URLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLTests.swift; sourceTree = "<group>"; };
 		0B96F02C1E2FD32000236DDE /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		0B96F02F1E2FD33C00236DDE /* UIEdgeInsetsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsetsTests.swift; sourceTree = "<group>"; };
+		2D919FCF212FC9440024A3AE /* TimePassed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePassed.swift; sourceTree = "<group>"; };
 		31F868DA1C2B6E5E00542250 /* DoubleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoubleExtensions.swift; sourceTree = "<group>"; };
 		50AD20181DDCE6FF00A5A863 /* FileManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileManagerTests.swift; sourceTree = "<group>"; };
 		5A02399C1E6D345C00C235B8 /* CollectionsExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionsExtension.swift; sourceTree = "<group>"; };
@@ -662,6 +666,7 @@
 				E19AC0EE1DCBA2BF00908905 /* URLExtensions.swift */,
 				E19AC0EB1DCBA28A00908905 /* UserDefaultsExtension.swift */,
 				0B96F02C1E2FD32000236DDE /* UIEdgeInsets.swift */,
+				2D919FCF212FC9440024A3AE /* TimePassed.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -986,6 +991,7 @@
 				5AF577A51EEE52DC00B1C277 /* UIUserInterfaceSizeClassExtensions.swift in Sources */,
 				5AF577A61EEE52DC00B1C277 /* UIViewControllerExtensions.swift in Sources */,
 				5AF577A71EEE52DC00B1C277 /* UIViewExtensions.swift in Sources */,
+				2D919FD2212FC9440024A3AE /* TimePassed.swift in Sources */,
 				5AF577A81EEE52DC00B1C277 /* UIWindowExtensions.swift in Sources */,
 				5AF577A91EEE52DC00B1C277 /* URLExtensions.swift in Sources */,
 				5AF577AA1EEE52DC00B1C277 /* UserDefaultsExtension.swift in Sources */,
@@ -1103,6 +1109,7 @@
 				B5DC87341C0ED34300972D0A /* UIImageViewExtensions.swift in Sources */,
 				B5DC87351C0ED34300972D0A /* UILabelExtensions.swift in Sources */,
 				B5DC87361C0ED34300972D0A /* UITextViewExtensions.swift in Sources */,
+				2D919FD0212FC9440024A3AE /* TimePassed.swift in Sources */,
 				E19AC0E91DCBA26500908905 /* DateExtensions.swift in Sources */,
 				B5DC87371C0ED34300972D0A /* UIViewControllerExtensions.swift in Sources */,
 				B5DC87381C0ED34300972D0A /* UIViewExtensions.swift in Sources */,
@@ -1208,6 +1215,7 @@
 				CD4D30CE1CEEAFD900CB53BC /* UIButtonExtensions.swift in Sources */,
 				E19AC0F31DCBA2CE00908905 /* TimerExtensions.swift in Sources */,
 				CD4D30CF1CEEAFD900CB53BC /* UIColoredView.swift in Sources */,
+				2D919FD1212FC9440024A3AE /* TimePassed.swift in Sources */,
 				79AB4F331D03394F009183EC /* UIApplicationExtensions.swift in Sources */,
 				CD4D30D01CEEAFD900CB53BC /* UIColorExtensions.swift in Sources */,
 				CD4D30D11CEEAFD900CB53BC /* UIDeviceExtensions.swift in Sources */,

--- a/EZSwiftExtensionsTests/DateTests.swift
+++ b/EZSwiftExtensionsTests/DateTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import EZSwiftExtensions
 
 class DateTests: XCTestCase {
     // note that Date uses UTC in Date(timeIntervalSince1970: _)
@@ -169,6 +170,41 @@ class DateTests: XCTestCase {
         
         let fifteenYearsAgo = Calendar.current.date(byAdding: .year, value: -15,to: today)
         XCTAssertEqual(fifteenYearsAgo?.timePassed(), "15 years ago")
+    }
+    
+    func testTimePassedEnumBetweenDates() {
+        
+        let today = Date()
+        let timePassedToday: TimePassed = today.timePassed()
+        XCTAssertEqual(timePassedToday, TimePassed.now)
+        
+        let fifteenYearsAgo = Calendar.current.date(byAdding: .year, value: -15, to: today)
+        let timePassedFifteenYearsAgo: TimePassed = fifteenYearsAgo!.timePassed()
+        XCTAssertEqual(timePassedFifteenYearsAgo, TimePassed.year(15))
+        
+        let twoMonthsAgo = Calendar.current.date(byAdding: .month, value: -2, to: today)
+        let timePassedTwoMonthsAgo: TimePassed = twoMonthsAgo!.timePassed()
+        XCTAssertEqual(timePassedTwoMonthsAgo, TimePassed.month(2))
+        
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today)
+        let timePassedYesterday: TimePassed = yesterday!.timePassed()
+        XCTAssertEqual(timePassedYesterday, TimePassed.day(1))
+        
+        let sixHoursAgo = Calendar.current.date(byAdding: .hour, value: -6, to: today)
+        let timePassedSixHoursAgo: TimePassed = sixHoursAgo!.timePassed()
+        XCTAssertEqual(timePassedSixHoursAgo, TimePassed.hour(6))
+        
+        let thirteenMinutesAgo = Calendar.current.date(byAdding: .minute, value: -13, to: today)
+        let timePassedThirteenMinutesAgo: TimePassed = thirteenMinutesAgo!.timePassed()
+        XCTAssertEqual(timePassedThirteenMinutesAgo, TimePassed.minute(13))
+        
+        let fiveSecondsAgo = Calendar.current.date(byAdding: .second, value: -5, to: today)
+        let timePassedFiveSecondsAgo: TimePassed = fiveSecondsAgo!.timePassed()
+        XCTAssertEqual(timePassedFiveSecondsAgo, TimePassed.second(5))
+        
+        let oneSecondAgo = Calendar.current.date(byAdding: .second, value: -1, to: today)
+        let timePassedOneSecondAgo: TimePassed = oneSecondAgo!.timePassed()
+        XCTAssertEqual(timePassedOneSecondAgo, TimePassed.second(1))
     }
     
     func testIsPast() {

--- a/Sources/DateExtensions.swift
+++ b/Sources/DateExtensions.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Date {
-
+    
     public static let minutesInAWeek = 24 * 60 * 7
 
     /// EZSE: Initializes Date from string and format
@@ -133,6 +133,30 @@ extension Date {
             return "\(components.second!) \(str) ago"
         } else {
             return "Just now"
+        }
+    }
+    
+    /// EZSE: Easy creation of time passed String. Can be Years, Months, days, hours, minutes or seconds. Useful for localization
+    public func timePassed() -> TimePassed {
+        
+        let date = Date()
+        let calendar = Calendar.autoupdatingCurrent
+        let components = (calendar as NSCalendar).components([.year, .month, .day, .hour, .minute, .second], from: self, to: date, options: [])
+        
+        if components.year! >= 1 {
+            return TimePassed.year(components.year!)
+        } else if components.month! >= 1 {
+            return TimePassed.month(components.month!)
+        } else if components.day! >= 1 {
+            return TimePassed.day(components.day!)
+        } else if components.hour! >= 1 {
+            return TimePassed.hour(components.hour!)
+        } else if components.minute! >= 1 {
+            return TimePassed.minute(components.minute!)
+        } else if components.second! >= 1 {
+            return TimePassed.second(components.second!)
+        } else {
+            return TimePassed.now
         }
     }
     

--- a/Sources/TimePassed.swift
+++ b/Sources/TimePassed.swift
@@ -1,0 +1,53 @@
+//
+//  TimePassed.swift
+//  EZSwiftExtensions
+//
+//  Created by Jaja Yting on 24/08/2018.
+//  Copyright © 2018 Goktug Yilmaz. All rights reserved.
+//
+
+import Foundation
+
+public enum TimePassed {
+    
+    case year(Int)
+    case month(Int)
+    case day(Int)
+    case hour(Int)
+    case minute(Int)
+    case second(Int)
+    case now
+}
+
+extension TimePassed: Equatable {
+    
+    public static func ==(lhs: TimePassed, rhs: TimePassed) -> Bool {
+        
+        switch(lhs, rhs) {
+            
+        case (.year(let a), .year(let b)):
+            return a == b
+            
+        case (.month(let a), .month(let b)):
+            return a == b
+            
+        case (.day(let a), .day(let b)):
+            return a == b
+            
+        case (.hour(let a), .hour(let b)):
+            return a == b
+            
+        case (.minute(let a), .minute(let b)):
+            return a == b
+            
+        case (.second(let a), .second(let b)):
+            return a == b
+            
+        case (.now, .now):
+            return true
+            
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
The overload of the method -timePassed returns an enum of TimePassed. Instances of TimePassed can be `.year(int)`, `.month(int)`, `.day(int)`, `.hour(int)`, `.minute(int)`, `.second(int)`, and `now`.

Original implementation of the -timePassed method returns a string eg. `5 seconds ago`, `13 years ago`. It is really convenient for the consumer of this method, if the target build is on english, but it is really cumbersome if the target is non-english builds. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! 😬 -->
- [ ] New Extension
- [x] New Test
- [ ] Changed more than one extension, but all changes are related
- [ ] Trivial change (doesn't require changelog)